### PR TITLE
Return error descriptions in response

### DIFF
--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -12,9 +12,16 @@ public func routes(
     }
 
     commands.forEach { command in
-        router.post(command.name) { req in
-            try attempt {
-                try slack.handle(command: command, on: req)
+        router.post(command.name) { req -> Future<Response> in
+            do {
+                return try attempt {
+                    try slack.handle(command: command, on: req)
+                }
+            } catch {
+                return try SlackResponse(
+                    error.localizedDescription,
+                    visibility: .user
+                ).encode(for: req)
             }
         }
     }

--- a/Sources/Stevenson/Errors.swift
+++ b/Sources/Stevenson/Errors.swift
@@ -4,7 +4,7 @@ import Vapor
 extension SlackService {
     public enum Error: Swift.Error, Debuggable {
         case invalidToken
-        case invalidChannel
+        case invalidChannel(String)
         case missingParameter(key: String)
         case invalidParameter(key: String, value: String, expected: String)
 
@@ -16,11 +16,11 @@ extension SlackService {
             switch self {
             case .invalidToken:
                 return "Invalid token"
-            case .invalidChannel:
-                return "Invalid channel"
-            case .missingParameter(let key):
+            case let .invalidChannel(channel):
+                return "Invalid channel `\(channel)`"
+            case let .missingParameter(key):
                 return "Missing parameter for `\(key)`"
-            case .invalidParameter(let key, let value, let expected):
+            case let .invalidParameter(key, value, expected):
                 return "Invalid parameter `\(value)` for `\(key)`. Expected \(expected)."
             }
         }

--- a/Sources/Stevenson/SlackService.swift
+++ b/Sources/Stevenson/SlackService.swift
@@ -71,7 +71,7 @@ public struct SlackService {
             throw Error.invalidToken
         }
         if let requireChannel = requireChannel, metadata.channelName != requireChannel {
-            throw Error.invalidChannel
+            throw Error.invalidChannel(metadata.channelName)
         }
 
         if metadata.text == "help" {


### PR DESCRIPTION
It's an advised best practice to return responses when anything in the command failed.