### PR TITLE
CRP: Improve Slack Response and CHANGELOG format

### DIFF
--- a/Sources/App/commands.swift
+++ b/Sources/App/commands.swift
@@ -124,12 +124,12 @@ extension SlackCommand {
         let accountablePerson = isTelus ? "eric.schnitzer" : "andreea.papillon"
         // Remove brackets around JIRA ticket names so that it's recognized by JIRA as a ticket reference
         // eg replace "[CNSMR-123] Do this" with "CNSMR-123 Do this"
-        let cleanChangelog = changelog.replacingOccurrences(of: "\\[([A-Z]+-[0-9]+)\\]", with: "$1", options: [.regularExpression], range: nil)
+        let changelog = changelog.replacingOccurrences(of: "\\[([A-Z]+-[0-9]+)\\]", with: "$1", options: [.regularExpression], range: nil)
         let fields = JiraService.CRPIssueFields(
             summary: repoMapping.jiraSummary(release),
             environments: [repoMapping.environment],
             release: release,
-            changelog: cleanChangelog,
+            changelog: changelog,
             accountablePersonName: accountablePerson
         )
         return JiraService.CRPIssue(fields: fields)


### PR DESCRIPTION
 - Don't include `# <ticketID>` in the Slack reply since it's seens by Slack as a hexcolor 😉 
 - Use issue key (`CRP-xxx`) instead of issue ID in the Slack response
 - Fix the URL to the issue to be to `/browser` and not to `/rest/api/...`
 - Also remove brackets around JIRA ticket names found in CHANGELOG so that JIRA recognise/parse them as references and display them nicely