### PR TITLE
[CNSMR-1347] Move required channel into slack command and token into slack service

### DIFF
--- a/Sources/App/commands.swift
+++ b/Sources/App/commands.swift
@@ -13,7 +13,7 @@ extension SlackCommand {
             Example:
             `/fastlane test_babylon \(branchOptionPrefix)develop`
             """,
-            token: Environment.get("SLACK_TOKEN")!,
+            allowedChannels: ["ios-build"],
             run: { metadata, request in
                 let components = metadata.text.components(separatedBy: " ")
                 let lane = components[0]
@@ -45,7 +45,7 @@ extension SlackCommand {
                 Example:
                 `/crp ios branch:release/3.13.0`
                 """,
-            token: Environment.get("SLACK_TOKEN")!,
+            allowedChannels: ["ios-build"],
             run: { metadata, request in
                 let components = metadata.text.components(separatedBy: " ")
 

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -4,7 +4,7 @@ import Stevenson
 /// Called before your application initializes.
 public func configure(_ config: inout Config, _ env: inout Environment, _ services: inout Services) throws {
     let slack = SlackService(
-        requireChannel: Environment.get("SLACK_CHANNEL")
+        token: try attempt { Environment.get("SLACK_TOKEN") }
     )
 
     let ci = CircleCIService(

--- a/Sources/Stevenson/Errors.swift
+++ b/Sources/Stevenson/Errors.swift
@@ -4,7 +4,7 @@ import Vapor
 extension SlackService {
     public enum Error: Swift.Error, Debuggable {
         case invalidToken
-        case invalidChannel(String)
+        case invalidChannel(String, allowed: Set<String>)
         case missingParameter(key: String)
         case invalidParameter(key: String, value: String, expected: String)
 
@@ -16,8 +16,11 @@ extension SlackService {
             switch self {
             case .invalidToken:
                 return "Invalid token"
-            case let .invalidChannel(channel):
-                return "Invalid channel `\(channel)`"
+            case let .invalidChannel(channel, allowed):
+                return """
+                    Invalid channel `\(channel)`. Command should be invoked from one of these channels:
+                    \(allowed.map { "* `\($0)`" }.joined(separator: "\n"))
+                    """
             case let .missingParameter(key):
                 return "Missing parameter for `\(key)`"
             case let .invalidParameter(key, value, expected):

--- a/Sources/Stevenson/SlackService.swift
+++ b/Sources/Stevenson/SlackService.swift
@@ -7,7 +7,7 @@ public struct SlackCommand {
     /// Command usage instructions
     public let help: String
 
-    /// Channels where command should be allowed.
+    /// Channels from which this command is allowed to be triggered.
     /// If empty the command will be allowed in all channels
     public let allowedChannels: Set<String>
 
@@ -72,10 +72,10 @@ public struct SlackService {
             try request.content.syncDecode(SlackCommandMetadata.self)
         }
 
-        if metadata.token != token {
+        guard metadata.token == token else {
             throw Error.invalidToken
         }
-        if !command.allowedChannels.isEmpty && !command.allowedChannels.contains(metadata.channelName) {
+        guard command.allowedChannels.isEmpty || command.allowedChannels.contains(metadata.channelName) else {
             throw Error.invalidChannel
         }
 

--- a/Sources/Stevenson/SlackService.swift
+++ b/Sources/Stevenson/SlackService.swift
@@ -75,8 +75,9 @@ public struct SlackService {
         guard metadata.token == token else {
             throw Error.invalidToken
         }
+
         guard command.allowedChannels.isEmpty || command.allowedChannels.contains(metadata.channelName) else {
-            throw Error.invalidChannel(metadata.channelName)
+            throw Error.invalidChannel(metadata.channelName, allowed: command.allowedChannels)
         }
 
         if metadata.text == "help" {


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/CNSMR-1347

### Why?
When creating a separate slack app, rather than creating slash commands in existing "Slash Commands" app, which is probably a more likely use case, all slash commands created in such new app will share the same token, so it makes sense to make it a trait of slack service.

Required channel though can be different for different commands so should be part of the slash command declaration itself.

### How?
- move `token` property from `SlackCommand` to `SlackService`
- move `requiredChannel` property from `SlackService` to `allowedChannels` in `SlackCommand`. If it's empty set, assume that command is allowed in any channel

### PR checklist

* [x] I've assigned this PR to myself

With :heart: