### PR TITLE
[CNSMR-1348] Run slack commands after returning response

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   linux:
     docker:
-      - image: swift:4.1
+      - image: swift:4.2
     steps:
       - checkout
       - run: 
@@ -15,7 +15,7 @@ jobs:
 
   linux-release:
     docker:
-      - image: swift:4.1
+      - image: swift:4.2
     steps:
       - checkout
       - run: 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:4.2
 import PackageDescription
 
 let package = Package(

--- a/Sources/App/commands.swift
+++ b/Sources/App/commands.swift
@@ -26,7 +26,7 @@ extension SlackCommand {
                     .run(command: command, branch: branch, on: request)
                     .map {
                         SlackResponse("""
-                            Triggered `\(command.name)` on the `\($0.branch)` branch.
+                            🚀 Triggered `\(command.name)` on the `\($0.branch)` branch.
                             \($0.buildURL)
                             """
                         )

--- a/Sources/App/commands.swift
+++ b/Sources/App/commands.swift
@@ -30,7 +30,11 @@ extension SlackCommand {
                             \($0.buildURL)
                             """
                         )
-                }
+                    }.replyLater(
+                        withImmediateResponse: SlackResponse("👍", visibility: .user),
+                        responseURL: metadata.responseURL,
+                        request: request
+                )
         })
     }
 
@@ -61,6 +65,7 @@ extension SlackCommand {
                 guard let branchName = branch(fromOptions: components) else {
                     throw SlackService.Error.missingParameter(key: "branch")
                 }
+
                 let release = try makeGitHubRelease(repo: repoMapping.repository, branch: branchName)
                 return try githubService.changelog(for: release, on: request)
                     .map { changelog in
@@ -76,11 +81,15 @@ extension SlackCommand {
                     .catchError(.capture())
                     .map { issue in
                         SlackResponse("""
-                            CRP Ticket \(issue.key) created.
+                            ✅ CRP Ticket \(issue.key) created.
                             https://\(jiraService.host)/browse/\(issue.key)
                             """
                         )
-                }
+                    }.replyLater(
+                        withImmediateResponse: SlackResponse("🎫 Creating ticket...", visibility: .user),
+                        responseURL: metadata.responseURL,
+                        request: request
+                )
         })
     }
 


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/CNSMR-1348

### Why?
Slash command can take more time then required by slack (3s) to get response from all services involved (CircleCI, GitHub, Jira), so we should use delayed responses rather than waiting for all requests to these services to finish.

### How?
Return "ok" response and then run command and post its result to `response_url` included in a slack message.

### PR checklist

* [x] I've assigned this PR to myself

With :heart:
