### PR TITLE
[CNSMR-1383] Added shortcut commands for hockeyapp and testflight lanes

### DIFF
--- a/Sources/App/CRP/SlackCommand+CRP.swift
+++ b/Sources/App/CRP/SlackCommand+CRP.swift
@@ -58,7 +58,8 @@ extension SlackCommand {
                         SlackResponse("""
                             ✅ CRP Ticket \(issue.key) created.
                             \(jira.baseURL)/browse/\(issue.key)
-                            """
+                            """,
+                            visibility: .channel
                         )
                     }.replyLater(
                         withImmediateResponse: SlackResponse("🎫 Creating ticket..."),

--- a/Sources/App/CRP/SlackCommand+CRP.swift
+++ b/Sources/App/CRP/SlackCommand+CRP.swift
@@ -21,20 +21,20 @@ extension SlackCommand {
                 let components = metadata.text.components(separatedBy: " ")
 
                 guard let repo = components.first else {
-                    throw SlackService.Error.missingParameter(key: Option.repo)
+                    throw SlackService.Error.missingParameter(key: Option.repo.value)
                 }
 
                 guard let repoMapping = RepoMapping.all[repo.lowercased()] else {
                     let all = RepoMapping.all.keys.joined(separator: "|")
                     throw SlackService.Error.invalidParameter(
-                        key: Option.repo,
+                        key: Option.repo.value,
                         value: repo,
                         expected: all
                     )
                 }
 
-                guard let branch = metadata.value(forOption: Option.branch) else {
-                    throw SlackService.Error.missingParameter(key: Option.branch)
+                guard let branch = metadata.value(forOption: .branch) else {
+                    throw SlackService.Error.missingParameter(key: Option.branch.value)
                 }
 
                 let release = try github.makeGitHubRelease(

--- a/Sources/App/CRP/SlackCommand+CRP.swift
+++ b/Sources/App/CRP/SlackCommand+CRP.swift
@@ -11,7 +11,7 @@ extension SlackCommand {
 
             Parameters:
             - project identifier (e.g: `ios`, `android`)
-            - branch: release branch name (e.g. `release/<version>`, `release/<app>/<version>`)
+            - `branch`: release branch name (e.g. `release/<version>`, `release/<app>/<version>`)
 
             Example:
             `/crp ios \(Option.branch):release/3.13.0`
@@ -33,7 +33,7 @@ extension SlackCommand {
                     )
                 }
 
-                guard let branch = SlackCommand.branch(fromOptions: components) else {
+                guard let branch = metadata.value(forOption: Option.branch) else {
                     throw SlackService.Error.missingParameter(key: Option.branch)
                 }
 
@@ -61,7 +61,7 @@ extension SlackCommand {
                             """
                         )
                     }.replyLater(
-                        withImmediateResponse: SlackResponse("🎫 Creating ticket...", visibility: .user),
+                        withImmediateResponse: SlackResponse("🎫 Creating ticket..."),
                         responseURL: metadata.responseURL,
                         request: request
                 )

--- a/Sources/App/Fastlane/SlackCommand+Fastlane.swift
+++ b/Sources/App/Fastlane/SlackCommand+Fastlane.swift
@@ -7,44 +7,118 @@ extension SlackCommand {
         SlackCommand(
             name: "fastlane",
             help: """
-            Invokes specified lane on specified branch (or develop if not specified).
+            Invokes specified lane on specified branch.
             Provide options the same way as when invoking lane locally.
 
             Parameters:
             - name of the lane to run
-            - list of lane options in fastlane format (e.g. `device:iPhone5s`)
-            - branch: name of the branch to run the lane on
+            - list of lane options in the fastlane format (e.g. `device:iPhone5s`)
+            - `branch`: name of the branch to run the lane on. Default is `\(RepoMapping.ios.repository.baseBranch)`
 
             Example:
             `/fastlane test_babylon \(Option.branch):develop`
             """,
             allowedChannels: ["ios-build"],
             run: { metadata, request in
-                let components = metadata.text.components(separatedBy: " ")
-                let lane = components[0]
-                let options = components.dropFirst().joined(separator: " ")
-                let args = ["FASTLANE": lane, "OPTIONS": options]
-                let command = Command(name: lane, arguments: args)
-                let branch = SlackCommand.branch(fromOptions: components)
-
-                return try ci
-                    .run(
-                        command: command,
-                        project: RepoMapping.ios.repository.fullName,
-                        branch: branch ?? RepoMapping.ios.repository.baseBranch,
-                        request: request
-                    )
-                    .map {
-                        SlackResponse("""
-                            🚀 Triggered `\(command.name)` on the `\($0.branch)` branch.
-                            \($0.buildURL)
-                            """
-                        )
-                    }.replyLater(
-                        withImmediateResponse: SlackResponse("👍", visibility: .user),
-                        responseURL: metadata.responseURL,
-                        request: request
+                try runLane(
+                    metadata: metadata,
+                    ci: ci,
+                    request: request
                 )
         })
     }
+
+    static let testflight = { (ci: CircleCIService) in
+        SlackCommand(
+            name: "testflight",
+            help: """
+            Makes a new release candidate for Testflight. Shorthand for `/fastlane testflight`.
+
+            Parameters:
+            - name of the target
+            - `version`: version of the app
+            - `branch`: release branch name. Default is `release/<version>`
+
+            Example:
+            `/testflight Babylon \(Option.version):3.13.0`
+            """,
+            allowedChannels: ["ios-build"],
+            run: { metadata, request in
+                try runLane(
+                    metadata: SlackCommandMetadata(
+                        token: metadata.token,
+                        channelName: metadata.channelName,
+                        text: "testflight target:\(metadata.text)",
+                        responseURL: metadata.responseURL
+                    ),
+                    branch: metadata.value(forOption: Option.version).map { "release/\($0)" },
+                    ci: ci,
+                    request: request
+                )
+        })
+    }
+
+    static let hockeyapp = { (ci: CircleCIService) in
+        SlackCommand(
+            name: "hockeyapp",
+            help: """
+            Makes a new beta build for HockeyApp. Shorthand for `/fastlane hockeyapp`.
+
+            Parameters:
+            - name of the target
+            - `branch`: name of the branch to run the lane on. Default is `\(RepoMapping.ios.repository.baseBranch)`
+
+            Example:
+            `/hockeyapp Babylon \(Option.branch):develop`
+            """,
+            allowedChannels: ["ios-build"],
+            run: { metadata, request in
+                try runLane(
+                    metadata: SlackCommandMetadata(
+                        token: metadata.token,
+                        channelName: metadata.channelName,
+                        text: "hockeyapp target:\(metadata.text)",
+                        responseURL: metadata.responseURL
+                    ),
+                    ci: ci,
+                    request: request
+                )
+        })
+    }
+
+    private static func runLane(
+        metadata: SlackCommandMetadata,
+        branch: String? = nil,
+        ci: CircleCIService,
+        request: Request
+    ) throws -> Future<SlackResponse> {
+        let components = metadata.text.components(separatedBy: " ")
+        let lane = components[0]
+        let options = components.dropFirst().joined(separator: " ")
+        let branch = branch ?? metadata.value(forOption: Option.branch)
+
+        let args = ["FASTLANE": lane, "OPTIONS": options]
+        let command = Command(name: lane, arguments: args)
+
+        return try ci
+            .run(
+                command: command,
+                project: RepoMapping.ios.repository.fullName,
+                branch: branch ?? RepoMapping.ios.repository.baseBranch,
+                request: request
+            )
+            .map {
+                SlackResponse("""
+                    🚀 Triggered `\(command.name)` on the `\($0.branch)` branch.
+                    \($0.buildURL)
+                    """,
+                    visibility: .channel
+                )
+            }.replyLater(
+                withImmediateResponse: SlackResponse("👍"),
+                responseURL: metadata.responseURL,
+                request: request
+        )
+    }
+
 }

--- a/Sources/App/GitHubService+Release.swift
+++ b/Sources/App/GitHubService+Release.swift
@@ -22,7 +22,7 @@ extension GitHubService {
             version = branchComponents[2]
         } else {
             throw SlackService.Error.invalidParameter(
-                key: SlackCommand.Option.branch,
+                key: SlackCommand.Option.branch.value,
                 value: branch,
                 expected: "(release|hotfix)/<app>/<version>"
             )

--- a/Sources/App/SlackCommand+Options.swift
+++ b/Sources/App/SlackCommand+Options.swift
@@ -12,9 +12,8 @@ extension SlackCommand {
 
 extension SlackCommandMetadata {
     func value(forOption option: String) -> String? {
-        let components = text.components(separatedBy: " ")
         let optionPrefix = option + ":"
-        let branch = components.dropFirst()
+        let branch = textComponents.dropFirst()
             .first { $0.hasPrefix(optionPrefix) }?
             .dropFirst(optionPrefix.count)
         return branch.map(String.init)

--- a/Sources/App/SlackCommand+Options.swift
+++ b/Sources/App/SlackCommand+Options.swift
@@ -6,13 +6,17 @@ extension SlackCommand {
     enum Option {
         static let branch = "branch"
         static let repo = "repo"
+        static let version = "version"
     }
+}
 
-    static func branch(fromOptions options: [String]) -> String? {
-        let branchOptionPrefix = Option.branch + ":"
-        let branch = options.dropFirst()
-            .first { $0.hasPrefix(branchOptionPrefix) }?
-            .dropFirst(branchOptionPrefix.count)
+extension SlackCommandMetadata {
+    func value(forOption option: String) -> String? {
+        let components = text.components(separatedBy: " ")
+        let optionPrefix = option + ":"
+        let branch = components.dropFirst()
+            .first { $0.hasPrefix(optionPrefix) }?
+            .dropFirst(optionPrefix.count)
         return branch.map(String.init)
     }
 }

--- a/Sources/App/SlackCommand+Options.swift
+++ b/Sources/App/SlackCommand+Options.swift
@@ -3,16 +3,21 @@ import Vapor
 import Stevenson
 
 extension SlackCommand {
-    enum Option {
-        static let branch = "branch"
-        static let repo = "repo"
-        static let version = "version"
+    struct Option {
+        let value: String
+        private init(_ value: String) {
+            self.value = value
+        }
+
+        static let branch   = Option("branch")
+        static let repo     = Option("repo")
+        static let version  = Option("version")
     }
 }
 
 extension SlackCommandMetadata {
-    func value(forOption option: String) -> String? {
-        let optionPrefix = option + ":"
+    func value(forOption option: SlackCommand.Option) -> String? {
+        let optionPrefix = option.value + ":"
         let branch = textComponents.dropFirst()
             .first { $0.hasPrefix(optionPrefix) }?
             .dropFirst(optionPrefix.count)

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -25,6 +25,8 @@ public func configure(_ config: inout Config, _ env: inout Environment, _ servic
     let router = EngineRouter.default()
     try routes(router: router, slack: slack, commands: [
         .fastlane(ci),
+        .hockeyapp(ci),
+        .testflight(ci),
         .crp(jira, github)
     ])
     services.register(router, as: Router.self)

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -18,10 +18,8 @@ public func routes(
                     try slack.handle(command: command, on: req)
                 }
             } catch {
-                return try SlackResponse(
-                    error.localizedDescription,
-                    visibility: .user
-                ).encode(for: req)
+                return try SlackResponse(error.localizedDescription)
+                    .encode(for: req)
             }
         }
     }

--- a/Sources/Stevenson/GitHubService.swift
+++ b/Sources/Stevenson/GitHubService.swift
@@ -14,7 +14,7 @@ public struct GitHubService {
     }
 }
 
-public extension GitHubService {
+extension GitHubService {
     public struct CommitList: Content {
         let total_commits: Int
         let commits: [Commit]
@@ -57,7 +57,7 @@ public extension GitHubService {
             .catchError(.capture())
     }
 
-    func changelog(for release: Release, request: Request) throws -> Future<String> {
+    public func changelog(for release: Release, request: Request) throws -> Future<String> {
         let repo = release.repository
         return try commitList(
             in: repo,

--- a/Sources/Stevenson/JiraService.swift
+++ b/Sources/Stevenson/JiraService.swift
@@ -24,7 +24,7 @@ public protocol JiraIssueFields: Content {
     var issueType: JiraService.FieldType.ObjectID { get }
 }
 
-public extension JiraService {
+extension JiraService {
     public struct Issue<Fields: JiraIssueFields>: Content {
         let fields: Fields
         public init(fields: Fields) {
@@ -60,7 +60,7 @@ public extension JiraService {
 
 // MARK: Jira Common Field Types
 
-public extension JiraService {
+extension JiraService {
     public enum FieldType {
         public enum TextArea {
             public struct Document: Content {

--- a/Sources/Stevenson/SlackService.swift
+++ b/Sources/Stevenson/SlackService.swift
@@ -32,6 +32,18 @@ public struct SlackCommandMetadata: Content {
     public let text: String
     public let responseURL: String
 
+    public init(
+        token: String,
+        channelName: String,
+        text: String,
+        responseURL: String
+    ) {
+        self.token = token
+        self.channelName = channelName
+        self.text = text
+        self.responseURL = responseURL
+    }
+
     enum CodingKeys: String, CodingKey {
         case token
         case channelName = "channel_name"
@@ -56,7 +68,7 @@ public struct SlackResponse: Content {
         case visibility = "response_type"
     }
 
-    public init(_ text: String, visibility: Visibility = .channel) {
+    public init(_ text: String, visibility: Visibility = .user) {
         self.text = text
         self.visibility = visibility
     }
@@ -88,7 +100,7 @@ public struct SlackService {
         } else {
             return try command
                 .run(metadata, request)
-                .mapIfError { SlackResponse($0.localizedDescription, visibility: .user) }
+                .mapIfError { SlackResponse($0.localizedDescription) }
                 .encode(for: request)
         }
     }
@@ -102,7 +114,7 @@ extension Future where T == SlackResponse {
         request: Request
     ) -> Future<SlackResponse> {
         _ = self
-            .mapIfError { SlackResponse($0.localizedDescription, visibility: .user) }
+            .mapIfError { SlackResponse($0.localizedDescription) }
             .flatMap { response in
                 try request.client()
                     .post(responseURL, headers: ["Content-type": "application/json"]) {

--- a/Sources/Stevenson/SlackService.swift
+++ b/Sources/Stevenson/SlackService.swift
@@ -30,6 +30,7 @@ public struct SlackCommandMetadata: Content {
     public let token: String
     public let channelName: String
     public let text: String
+    public let textComponents: [String.SubSequence]
     public let responseURL: String
 
     public init(
@@ -41,6 +42,7 @@ public struct SlackCommandMetadata: Content {
         self.token = token
         self.channelName = channelName
         self.text = text
+        self.textComponents = text.split(separator: " ")
         self.responseURL = responseURL
     }
 
@@ -49,6 +51,16 @@ public struct SlackCommandMetadata: Content {
         case channelName = "channel_name"
         case text
         case responseURL = "response_url"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self = try SlackCommandMetadata(
+            token:          container.decode(String.self, forKey: .token),
+            channelName:    container.decode(String.self, forKey: .channelName),
+            text:           container.decode(String.self, forKey: .text),
+            responseURL:    container.decode(String.self, forKey: .responseURL)
+        )
     }
 }
 


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/CNSMR-1383
Depends on #12 

### Why?
To make it easier to invoke most common lanes

### How?
Add new commands which are effectively shorthands for `fastlane` command

### PR checklist

* [x] I've assigned this PR to myself

With :heart:
