### PR TITLE
[CNSMR-2048] CRP: account for new branch naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For example to simulate `/fastlane somelane someargs`, use this (adapt the `&tex
 curl --request POST \
   --url http://localhost:8080/fastlane \
   --header 'content-type: application/x-www-form-urlencoded' \
-  --data 'token=__SLACK_TOKEN__&channel_name= __SLACK_CHANNEL__&text=somelane%20someargs'
+  --data 'token=__SLACK_TOKEN__&channel_name=__SOME_SLACK_CHANNEL__&text=somelane%20someargs'
 ```
 
 ## 🕹 Adding a new Slack command to the app

--- a/Sources/App/CRP/JiraService+CRP.swift
+++ b/Sources/App/CRP/JiraService+CRP.swift
@@ -8,8 +8,8 @@ extension JiraService {
         changelog: String
     ) -> CRPIssue {
         // [CNSMR-1319] TODO: Use a config file to parametrise accountable person
-        let isTelus = release.appName?.caseInsensitiveCompare("Telus") == .orderedSame
-        let accountablePerson = isTelus ? "eric.schnitzer" : "andreea.papillon"
+        let isTelus = release.appName.caseInsensitiveCompare("Telus") == .orderedSame
+        let accountablePerson = isTelus ? "ryan.covill" : "andreea.papillon"
         // Remove brackets around JIRA ticket names so that it's recognized by JIRA as a ticket reference
         // eg replace "[CNSMR-123] Do this" with "CNSMR-123 Do this"
         let changelog = changelog.replacingOccurrences(of: "\\[([A-Z]+-[0-9]+)\\]", with: "$1", options: [.regularExpression], range: nil)

--- a/Sources/App/CRP/SlackCommand+CRP.swift
+++ b/Sources/App/CRP/SlackCommand+CRP.swift
@@ -69,7 +69,8 @@ extension SlackCommand {
     }
 }
 
-/// Filter the CHANGELOG entries then orders and format the CHANGELOG text
+
+/// Filters the CHANGELOG entries then orders and formats the CHANGELOG text
 ///
 /// - Parameters:
 ///   - commits: The list of commits gathered between last release and current one

--- a/Sources/App/CRP/SlackCommand+CRP.swift
+++ b/Sources/App/CRP/SlackCommand+CRP.swift
@@ -11,25 +11,22 @@ extension SlackCommand {
 
             Parameters:
             - project identifier (e.g: `ios`, `android`)
-            - `branch`: release branch name (e.g. `release/<version>`, `release/<app>/<version>`)
+            - `branch`: release branch name (typically `release/<app>/<version>`, e.g. `release/babylon/4.1.0`)
 
             Example:
-            `/crp ios \(Option.branch.value):release/3.13.0`
+            `/crp ios \(Option.branch.value):release/babylon/4.1.0`
             """,
-            allowedChannels: ["ios-build"],
+            allowedChannels: ["ios-launchpad"],
             run: { metadata, container in
-                let components = metadata.text.components(separatedBy: " ")
-
-                guard let repo = components.first else {
+                guard let repo = metadata.textComponents.first else {
                     throw SlackService.Error.missingParameter(key: Option.repo.value)
                 }
 
                 guard let repoMapping = RepoMapping.all[repo.lowercased()] else {
-                    let all = RepoMapping.all.keys.joined(separator: "|")
                     throw SlackService.Error.invalidParameter(
                         key: Option.repo.value,
-                        value: repo,
-                        expected: all
+                        value: String(repo),
+                        expected: RepoMapping.all.keys.joined(separator: "|")
                     )
                 }
 

--- a/Sources/App/GitHubService+Release.swift
+++ b/Sources/App/GitHubService+Release.swift
@@ -8,24 +8,20 @@ extension GitHubService.Release {
     ) throws {
         let branchComponents = branch.components(separatedBy: "/")
         // [CNSMR-1319] TODO: Use a config file to parametrise branch format
-        guard branchComponents.count > 1, ["release", "hotfix"].contains(branchComponents[0]) else {
-            throw SlackService.Error.invalidParameter(key: "branch", value: branch, expected: "release or hotfix branch")
-        }
-        let (appName, version): (String?, String)
-        if branchComponents.count == 2 {
-            // in the form of "release/1.2.3" or "hotfix/1.2.3"
-            appName = nil
-            version = branchComponents[1]
-        } else if branchComponents.count == 3 {
-            // in the form of "release/appName/1.2.3" or "hotfix/appName/1.2.3"
-            appName = branchComponents[1]
-            version = branchComponents[2]
-        } else {
+
+        guard branchComponents.count == 3 else {
             throw SlackService.Error.invalidParameter(
                 key: SlackCommand.Option.branch.value,
                 value: branch,
                 expected: "(release|hotfix)/<app>/<version>"
             )
+        }
+
+        // in the form of "release/appName/1.2.3" or "hotfix/appName/1.2.3"
+        let (releaseType, appName, version) = (branchComponents[0], branchComponents[1], branchComponents[2])
+
+        guard ["release", "hotfix"].contains(releaseType) else {
+            throw SlackService.Error.invalidParameter(key: "branch", value: branch, expected: "release or hotfix branch")
         }
 
         self.init(

--- a/Sources/App/GitHubService+Release.swift
+++ b/Sources/App/GitHubService+Release.swift
@@ -28,7 +28,8 @@ extension GitHubService.Release {
             repository: repo,
             branch: branch,
             appName: appName,
-            version: version
+            version: version,
+            isMatchingTag: { $0.hasPrefix("\(appName)/") }
         )
     }
 

--- a/Sources/App/GitHubService+Release.swift
+++ b/Sources/App/GitHubService+Release.swift
@@ -31,4 +31,8 @@ extension GitHubService.Release {
             version: version
         )
     }
+
+    var isSDK: Bool {
+        return self.appName == "sdk"
+    }
 }

--- a/Sources/App/RepoMapping.swift
+++ b/Sources/App/RepoMapping.swift
@@ -20,7 +20,13 @@ extension RepoMapping {
         ),
         crp: CRP(
             environment: .appStore,
-            jiraSummary: { "Publish iOS \($0.appName) App v\($0.version) to the AppStore" }
+            jiraSummary: {
+                if $0.isSDK {
+                    return "Publish iOS SDK v\($0.version) to our partners"
+                } else {
+                    return "Publish iOS \($0.appName) App v\($0.version) to the AppStore"
+                }
+            }
         )
     )
 
@@ -31,7 +37,13 @@ extension RepoMapping {
         ),
         crp: CRP(
             environment: .playStore,
-            jiraSummary: { "Publish Android \($0.appName) App v\($0.version) to the PlayStore" }
+            jiraSummary: {
+                if $0.isSDK {
+                    return "Publish Android SDK v\($0.version) to our partners"
+                } else {
+                    return "Publish Android \($0.appName) App v\($0.version) to the PlayStore"
+                }
+            }
         )
     )
 

--- a/Sources/App/RepoMapping.swift
+++ b/Sources/App/RepoMapping.swift
@@ -20,7 +20,7 @@ extension RepoMapping {
         ),
         crp: CRP(
             environment: .appStore,
-            jiraSummary: { "Publish iOS \($0.appName ?? "Babylon") App v\($0.version) to the AppStore" }
+            jiraSummary: { "Publish iOS \($0.appName) App v\($0.version) to the AppStore" }
         )
     )
 
@@ -31,7 +31,7 @@ extension RepoMapping {
         ),
         crp: CRP(
             environment: .playStore,
-            jiraSummary: { "Publish Android \($0.appName ?? "Babylon") App v\($0.version) to the PlayStore" }
+            jiraSummary: { "Publish Android \($0.appName) App v\($0.version) to the PlayStore" }
         )
     )
 

--- a/Sources/Stevenson/GitHubService.swift
+++ b/Sources/Stevenson/GitHubService.swift
@@ -49,12 +49,14 @@ extension GitHubService {
         public let branch: String
         public let appName: String
         public let version: String
+        public let isMatchingTag: (String) -> Bool // To find a tag matching a previous version for the same app
 
-        public init(repository: Repository, branch: String, appName: String, version: String) {
+        public init(repository: Repository, branch: String, appName: String, version: String, isMatchingTag: @escaping (String) -> Bool) {
             self.repository = repository
             self.branch = branch
             self.appName = appName
             self.version = version
+            self.isMatchingTag = isMatchingTag
         }
     }
 }

--- a/Sources/Stevenson/GitHubService.swift
+++ b/Sources/Stevenson/GitHubService.swift
@@ -107,7 +107,7 @@ extension GitHubService {
         return try request(.capture()) {
             try container.client().get(url, headers: headers)
         }.map { (response: [Response]) -> [String] in
-                response.map { $0.tag_name }
+            response.map { $0.tag_name }
         }
     }
 }

--- a/Sources/Stevenson/GitHubService.swift
+++ b/Sources/Stevenson/GitHubService.swift
@@ -47,10 +47,10 @@ extension GitHubService {
     public struct Release {
         public let repository: Repository
         public let branch: String
-        public let appName: String?
+        public let appName: String
         public let version: String
 
-        public init(repository: Repository, branch: String, appName: String?, version: String) {
+        public init(repository: Repository, branch: String, appName: String, version: String) {
             self.repository = repository
             self.branch = branch
             self.appName = appName
@@ -85,6 +85,15 @@ extension GitHubService {
         }
     }
 
+    /// Return the list the tag names corresponding to all GitHub releases.
+    ///
+    /// The list is limited to the last 100 releases.
+    ///
+    /// - Parameters:
+    ///   - repo: The repository from which to get the GitHub Releases
+    ///   - container: The Vapor Container to run the request on
+    /// - Returns: List of tag names for the found GitHub releases.
+    /// - Throws: Vapor Exception if the request failed
     public func releases(
         in repo: Repository,
         on container: Container
@@ -95,8 +104,7 @@ extension GitHubService {
         let url = URL(string: "/repos/\(repo.fullName)/releases?per_page=100", relativeTo: baseURL)!
         return try request(.capture()) {
             try container.client().get(url, headers: headers)
-            }
-            .map { (response: [Response]) -> [String] in
+        }.map { (response: [Response]) -> [String] in
                 response.map { $0.tag_name }
         }
     }

--- a/app.json
+++ b/app.json
@@ -11,12 +11,6 @@
     "CIRCLECI_TOKEN": {
       "required": true
     },
-    "GITHUB_REPO_ANDROID": {
-      "required": true
-    },
-    "GITHUB_REPO_IOS": {
-      "required": true
-    },
     "GITHUB_TOKEN": {
       "required": true
     },
@@ -26,16 +20,10 @@
     "JIRA_BASEURL": {
       "required": true
     },
-    "JIRA_HOST": {
-      "required": true
-    },
     "JIRA_TOKEN": {
       "required": true
     },
     "JIRA_USERNAME": {
-      "required": true
-    },
-    "SLACK_CHANNEL": {
       "required": true
     },
     "SLACK_TOKEN": {


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/CNSMR-2048

### Why?

We are in the process of updating the release branch naming conventions.

This means that Stevenson has to know about the new `release/{app}/{version}` convention to extract the app and version from it, especially in order to support it for both the `/testflight` and `/crp` commands

### How?

* The `/testflight` command now guess the default branch name using the target and not just the version
* The generated CHANGELOG is now built by comparing the last matching GitHub Release / tag with the release branch being started (instead of using the `repo.baseBranch`)
* The generated CHANGELOG is now sorting the tickets by JIRA boards. This allows to easily see for example `TEL`-specific tickets in case of Telus releases
* The CRP command now supports the SDK: if the product being released is `sdk`, we'll filter the commits included in the CHANGELOG, and the CRP ticket title will also be adjusted
* The CRP command is now expected to be run in `#ios-launchpad` – since that's the place the changes and release notes for each new release is being discussed
* I updated the accountable person for Telus CRP tickets too
* I took the occasion to clean up some legacy env variables that were still listed in Heroku's `app.json`

### PR checklist

* [x] I've assigned this PR to myself

With :heart:
