### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,6 @@
-# Global rule for the whole codebase. Every PR needs to be reviewed by at least one permanent team member.
-# This empty team will act as a proxy for the PullAssigner bot. When a new PR arrives, PullAssigner will be triggered,
-# which will then pick members from the iOS-Admin team
-* @Babylonpartners/iOS-PullAssigner
+# Global rule for the whole codebase.
+#  - Every PR needs to be reviewed by at least one member of the `ios-bot-owners` team.
+#  - The empty `iOS-PullAssigner` team will act as a proxy for the PullAssigner bot.
+#    When a new PR arrives, PullAssigner will be triggered, which will then pick members from the iOS-Admin team
+
+* @Babylonpartners/iOS-PullAssigner @Babylonpartners/ios-bot-owners


### PR DESCRIPTION
Make it so that @Babylonpartners/ios-bot-owners members are always required to review for changes in Stevenson, in addition to the 3 people affected via Pull-Assigner

Ticket: https://babylonpartners.atlassian.net/browse/CNSMR-2281

### Why?

We want the rest of the team to start participating in reviewing PRs to our bots and get familiar with our bots' codebase, while still requiring at least one of the owners of our bot repos to approve as well

### How?

* Made PullAssigners work on Stevenson (was missing some config on our GH org's repo, fixed now)
* Created a @Babylonpartners/ios-bot-owners team to list people who will be owners of our bot repos (Stevenson and Wall-E). Currently @ilyapuchka , @dmcrodrigues and @AliSoftware are the members of this team
* Made `CODEOWNERS` request both a review from @Babylonpartners/ios-pullassigner and @Babylonpartners/ios-bot-owners
* Configured the repo to require reviews from owners, and updated the number of approvals to 2

![image](https://user-images.githubusercontent.com/216089/61451322-63058380-a959-11e9-98c1-7cd58ddd0aad.png)

### PR checklist

* [x] I've assigned this PR to myself

With :heart:
