### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,18 +146,18 @@ extension SlackCommand {
 You can skip step 1 and 2 if you have already set it up locally.
 
 1. Install the Heroku CLI.
-   ```
+   ```bash
    brew install heroku/brew/heroku
    heroku login
    ```
    
 2. Navigate to the local repo, and configure the Heroku remote using the CLI.
-   ```
+   ```bash
    heroku git:remote -a <heroku-app-name>
    ```
    
 3. Push the `master` branch to deploy.
-   ```
+   ```bash
    git checkout master
    git push heroku master
    ```


### PR DESCRIPTION
Dummy PR essentially aimed to check the behavior of the new CODEOWNERS setup

### Why?

Now that CODEOWNERS lists both `iOS-PullAssigner` and `ios-bot-owners` as owners of the whole codebase, we'd hope that only one of those (especially at least one person from`ios-bot-owners`) would be required, and that the PR would still be mergeable even if the proxy team `iOS-PullAssigners` didn't actually approve the PR

We need `iOS-PullAssigners` to be present in `CODEOWNERS` for PullAssigners to work and assign 3 people via round-robin
But we want `ios-bot-owners` to enforce at least one of the 3 people in that team validate the PR

### How?

This is a dummy PR just to check the behavior of GitHub on a new PR created after the CODEOWNERS change in #21 has been merged. We could in fact close this PR without merging if we want once we see how GH behaves

### PR checklist

* [x] I've assigned this PR to myself

With :heart:
