### PR TITLE
[CNSMR-2393] Updating JIRA projects whitelist + parse API errors

### DIFF
--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -13,7 +13,7 @@ private let jiraProjects = [
     "GW"    : 16949, // Triage UI
     // TODO: [CNSMR-2402] Re-enable IDM and MN once those boards have migrated to use the standard setup for their JIRA fields
     // "IDM"   : 16903, // Identity Platform / Identity Management
-    // "MN"    : 17031, // Monitor –
+    // "MN"    : 17031, // Monitor
     "MON"   : 10103, // HealthCheck
     "NRX"   : 16911, // Enrolment and Integrity
     "PAR"   : 17098, // Partnerships
@@ -21,7 +21,7 @@ private let jiraProjects = [
     "PRSCR" : 16840, // Prescriptions
     "SDK"   : 16975, // SDK
     "TEL"   : 16857, // Telus
-    "TES"   : 17074, // Tests & Kits
+    "TES"   : 17074, // Test Kits
     "WH"    : 17112, // Women's Health
 ]
 

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -2,24 +2,27 @@ import Vapor
 import Stevenson
 
 private let jiraProjects = [
-    "NRX"  : 16911, // Enrolment and Integrity
-    "CE"   : 16937, // Consultation Experience
-    "AV"   : 16942, // Core Experience / Avalon
-    "CW"   : 16832, // Consumer Web
-    "CNSMR": 16968, // Consumer Apps (Native/Core)
-    "MON"  : 10103, // HealthCheck
-    "GW"   : 16949, // Triage UI
-    "PRSCR": 16840, // Prescriptions
-    "SDK"  : 16975, // SDK
-    "APPTS": 16875, // Booking/Appointments
-    "TEL"  : 16857, // Telus
-    "PRO"  : 16980, // Professional Services
-    "PAR"  : 17098, // Partnerships
-    "MN"   : 17031, // Monitor
-    "TES"  : 17074, // Tests & Kits
-    "WH"   : 17112, // Women's Health
-    "IDM"  : 16903, // Identity Platform / Identity Management
-    "CM"   : 16920, // Condition Management
+    "APPTS" : 16875, // Booking/Appointments
+    "AV"    : 16942, // Core Experience / Avalon
+    "CE"    : 16937, // Consultation Experience
+    // TODO: [CNSMR-2402] Re-enable CM board once they've migrated all their tickets from private instance to main one
+    // "CM"    : 16920, // Condition Management
+    "CNSMR" : 16968, // Consumer Apps (Native/Core)
+    "COREUS": 17127, // Babylon US Core Product
+    "CW"    : 16832, // Consumer Web
+    "GW"    : 16949, // Triage UI
+    // TODO: [CNSMR-2402] Re-enable IDM and MN once those boards have migrated to use the standard setup for their JIRA fields
+    // "IDM"   : 16903, // Identity Platform / Identity Management
+    // "MN"    : 17031, // Monitor –
+    "MON"   : 10103, // HealthCheck
+    "NRX"   : 16911, // Enrolment and Integrity
+    "PAR"   : 17098, // Partnerships
+    "PRO"   : 16980, // Professional Services
+    "PRSCR" : 16840, // Prescriptions
+    "SDK"   : 16975, // SDK
+    "TEL"   : 16857, // Telus
+    "TES"   : 17074, // Tests & Kits
+    "WH"    : 17112, // Women's Health
 ]
 
 /// Called before your application initializes.

--- a/Sources/Stevenson/Errors.swift
+++ b/Sources/Stevenson/Errors.swift
@@ -83,8 +83,15 @@ extension JiraService: FailableService {
         public let identifier: String = "JiraService"
 
         public var reason: String {
-            let allErrors = errorMessages + errors.map { "\($0): \($1)" }
-            return allErrors.joined(separator: " ; ")
+            let allErrors = errorMessages + errors.sorted(by: <).map { "\($0): \($1)" }
+            if allErrors.count > 1 {
+                return allErrors
+                    .enumerated()
+                    .map { "[\($0.offset+1)] \($0.element)" }
+                    .joined(separator: " ")
+            } else {
+                return allErrors.first ?? "Unknown error"
+            }
         }
     }
 }

--- a/Sources/Stevenson/Errors.swift
+++ b/Sources/Stevenson/Errors.swift
@@ -76,12 +76,15 @@ extension GitHubService: FailableService {
 }
 
 extension JiraService: FailableService {
-    struct ServiceError: Swift.Error, Decodable, Debuggable {
-        let message: String
-        let identifier: String = "JiraService"
+    public struct ServiceError: Swift.Error, Decodable, Debuggable {
+        // https://developer.atlassian.com/cloud/jira/platform/rest/v3/?utm_source=%2Fcloud%2Fjira%2Fplatform%2Frest%2F&utm_medium=302#status-codes
+        public let errorMessages: [String]
+        public let errors: [String: String]
+        public let identifier: String = "JiraService"
 
-        var reason: String {
-            return message
+        public var reason: String {
+            let allErrors = errorMessages + errors.map { "\($0): \($1)" }
+            return allErrors.joined(separator: " ; ")
         }
     }
 }

--- a/Sources/Stevenson/Errors.swift
+++ b/Sources/Stevenson/Errors.swift
@@ -77,7 +77,7 @@ extension GitHubService: FailableService {
 
 extension JiraService: FailableService {
     public struct ServiceError: Swift.Error, Decodable, Debuggable {
-        // https://developer.atlassian.com/cloud/jira/platform/rest/v3/?utm_source=%2Fcloud%2Fjira%2Fplatform%2Frest%2F&utm_medium=302#status-codes
+        // See https://developer.atlassian.com/cloud/jira/platform/rest/v3/#status-codes for schema
         public let errorMessages: [String]
         public let errors: [String: String]
         public let identifier: String = "JiraService"

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -114,7 +114,7 @@ final class AppTests: XCTestCase {
         let error1 = try decoder.decode(JiraService.ServiceError.self, from: errorResponse1)
         XCTAssertEqual(error1.errorMessages, ["Issue does not exist or you do not have permission to see it.", "Some other message"])
         XCTAssertEqual(error1.errors, [:])
-        XCTAssertEqual(error1.reason, "Issue does not exist or you do not have permission to see it. ; Some other message")
+        XCTAssertEqual(error1.reason, "[1] Issue does not exist or you do not have permission to see it. [2] Some other message")
 
         let errorResponse2 = #"""
             {"errorMessages":[],"errors":{"fixVersions":"Field 'fixVersions' cannot be set. It is not on the appropriate screen, or unknown."}}
@@ -126,11 +126,18 @@ final class AppTests: XCTestCase {
         XCTAssertEqual(error2.reason, "fixVersions: Field 'fixVersions' cannot be set. It is not on the appropriate screen, or unknown.")
 
         let errorResponse3 = #"""
-            {"errorMessages":["msg1","msg2"],"errors":{"key1":"error1","key2":"error2"}}
+            {"errorMessages":["msg1.","msg2."],"errors":{"key1":"error1.","key2":"error2."}}
         """#.data(using: .utf8)!
 
         let error3 = try decoder.decode(JiraService.ServiceError.self, from: errorResponse3)
-        XCTAssertEqual(error3.reason, "msg1 ; msg2 ; key1: error1 ; key2: error2")
+        XCTAssertEqual(error3.reason, "[1] msg1. [2] msg2. [3] key1: error1. [4] key2: error2.")
+
+        let errorResponse4 = #"""
+            {"errorMessages":[],"errors":{}}
+        """#.data(using: .utf8)!
+
+        let error4 = try decoder.decode(JiraService.ServiceError.self, from: errorResponse4)
+        XCTAssertEqual(error4.reason, "Unknown error")
     }
 }
 

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -104,6 +104,34 @@ final class AppTests: XCTestCase {
         XCTAssertEqualJSON(update, expected, "Update Request JSON Mismatch")
     }
 
+    func testJiraErrors() throws {
+        let decoder = JSONDecoder()
+
+        let errorResponse1 = #"""
+            {"errorMessages":["Issue does not exist or you do not have permission to see it.","Some other message"],"errors":{}}
+        """#.data(using: .utf8)!
+
+        let error1 = try decoder.decode(JiraService.ServiceError.self, from: errorResponse1)
+        XCTAssertEqual(error1.errorMessages, ["Issue does not exist or you do not have permission to see it.", "Some other message"])
+        XCTAssertEqual(error1.errors, [:])
+        XCTAssertEqual(error1.reason, "Issue does not exist or you do not have permission to see it. ; Some other message")
+
+        let errorResponse2 = #"""
+            {"errorMessages":[],"errors":{"fixVersions":"Field 'fixVersions' cannot be set. It is not on the appropriate screen, or unknown."}}
+        """#.data(using: .utf8)!
+
+        let error2 = try decoder.decode(JiraService.ServiceError.self, from: errorResponse2)
+        XCTAssertEqual(error2.errorMessages, [])
+        XCTAssertEqual(error2.errors, ["fixVersions": "Field 'fixVersions' cannot be set. It is not on the appropriate screen, or unknown."])
+        XCTAssertEqual(error2.reason, "fixVersions: Field 'fixVersions' cannot be set. It is not on the appropriate screen, or unknown.")
+
+        let errorResponse3 = #"""
+            {"errorMessages":["msg1","msg2"],"errors":{"key1":"error1","key2":"error2"}}
+        """#.data(using: .utf8)!
+
+        let error3 = try decoder.decode(JiraService.ServiceError.self, from: errorResponse3)
+        XCTAssertEqual(error3.reason, "msg1 ; msg2 ; key1: error1 ; key2: error2")
+    }
 }
 
 

--- a/Tests/AppTests/XCTestManifests.swift
+++ b/Tests/AppTests/XCTestManifests.swift
@@ -8,6 +8,7 @@ extension AppTests {
     static let __allTests__AppTests = [
         ("testAddVersion", testAddVersion),
         ("testJiraDocumentFromCommits", testJiraDocumentFromCommits),
+        ("testJiraErrors", testJiraErrors),
         ("testVersion", testVersion),
     ]
 }


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/CNSMR-2393

### Why?

Last run of `/crp` generated [a lot of errors](https://babylonhealth.slack.com/archives/CJJ54RDFT/p1563800391003700):

1. One were due to `COREUS` not being whitelisted, I've added it to the whitelist
2. Multiple errors on `CM-xxx` tickets were due to the fact that CM currently have one board hosted on a separate, private (legacy?) JIRA instance, while some others are in the CM board on the main instance. We've decided in agreement with Andreea that until all tickets from the CM board are migrated to the main JIRA instance where all other projects are, we'll disable the FixedVersion feature for the CM project (thus removing it from whitelist), we'll re-enable it once all tickets are on the new board in the main instance
3. Errors on `MN` and `IDM` tickets were due to the fact that those JIRA projects don't use the standard setup for their fields. Instead they are configured as "next-gen" projects in JIRA, and have a lot of custom fields that are completely different from the other projects. MN and IDM plan to migrate back to the "Classic Project" setup for their boards in JIRA, and thus in the future use the same fields as all our other projects, but until they migrate to this we decided to remove them from the whitelist. We'll re-whitelist them once they've migrated.

For more details, see also https://babylonpartners.atlassian.net/browse/CNSMR-2402 which tracks that we'll need to re-whitelist CM, IDM and MN projects to the whitelist once they're ready.

Also, when a JIRA error occurred, we failed to parse the response body properly to create a readable error message.

### How?

* Reordered the whitelist dictionary literal in alphabetical order for readability
* Added `COREUS` project to the whitelist
* Commented out `CM`, `IDM` and `MN` entries from the whitelist, and left a `TODO:` referencing CNSMR-2402 to re-enable them later
* Fixed JIRA error messages parsing (`keyNotFound: message` when decoding the JSON body of an error response)

### PR checklist

* [x] I've assigned this PR to myself

With :heart:
