### PR TITLE
[CNSMR-2692] Fix regex detecting JIRA tickets

### DIFF
--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -21,7 +21,8 @@ private let jiraProjects = [
     "PRSCR" : 16840, // Prescriptions
     "SDK"   : 16975, // SDK
     "TEL"   : 16857, // Telus
-    "TES"   : 17074, // Test Kits
+    // TODO: [CNSMR-2402] Re-enable TES once this boards have migrated to use the standard setup for their JIRA fields
+    // "TES"   : 17074, // Test Kits
     "WH"    : 17112, // Women's Health
 ]
 

--- a/Sources/Stevenson/JiraService.swift
+++ b/Sources/Stevenson/JiraService.swift
@@ -57,7 +57,7 @@ extension JiraService {
             self.init(board: board, number: number)
         }
 
-        public static let regex = try! NSRegularExpression(pattern: #"\[?\b(([A-Za-z]*)-([0-9]*))\b\]?"#, options: [])
+        public static let regex = try! NSRegularExpression(pattern: #"\[?\b(([A-Za-z]+)-([0-9]+))\b\]?"#, options: [])
 
         private static func text(for match: NSTextCheckingResult?, at index: Int, in text: String) -> String? {
             return match

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -6,9 +6,12 @@ import XCTest
 final class AppTests: XCTestCase {
     static let fakeCommits = [
         "[CNSMR-2044] Commit 1",
-        "[CRP-4141] Commit 3",
-        "[CNSMR-2045] Commit 2",
-        "[CRP-4142] Commit 4"
+        // trap: we don't want it to match "sdk-core" as a ticket reference from the SDK board
+        "[CNSMR-1763] Migrate sdk-nhsgp into sdk-core (#8163)",
+        "[SDK-4142] Commit 2",
+        "[CNSMR-2045] Commit 3",
+        // trap: we don't want it to match "remote-tracking" as a ticket from the (non-existing) REMOTE nboard
+        "Merge remote-tracking branch 'origin/release/babylon/4.4.0' into develop",
     ]
 
     static let fakeVersion: JiraService.Version = {
@@ -33,13 +36,16 @@ final class AppTests: XCTestCase {
         )
 
         let entries = ChangelogSection.makeSections(from: AppTests.fakeCommits, for: release)
-        XCTAssertEqual(entries.count, 2)
+        XCTAssertEqual(entries.count, 3)
         XCTAssertEqual(entries[0].board, "CNSMR")
-        XCTAssertEqual(entries[0].commits.map { $0.message }, ["[CNSMR-2044] Commit 1", "[CNSMR-2045] Commit 2"])
-        XCTAssertEqual(entries[0].commits.map { $0.ticket?.key }, ["CNSMR-2044", "CNSMR-2045"])
-        XCTAssertEqual(entries[1].board, "CRP")
-        XCTAssertEqual(entries[1].commits.map { $0.message }, ["[CRP-4141] Commit 3", "[CRP-4142] Commit 4"])
-        XCTAssertEqual(entries[1].commits.map { $0.ticket?.key }, ["CRP-4141", "CRP-4142"])
+        XCTAssertEqual(entries[0].commits.map { $0.message }, ["[CNSMR-2044] Commit 1", "[CNSMR-1763] Migrate sdk-nhsgp into sdk-core (#8163)", "[CNSMR-2045] Commit 3"])
+        XCTAssertEqual(entries[0].commits.map { $0.ticket?.key }, ["CNSMR-2044", "CNSMR-1763", "CNSMR-2045"])
+        XCTAssertEqual(entries[1].board, "SDK")
+        XCTAssertEqual(entries[1].commits.map { $0.message }, ["[SDK-4142] Commit 2"])
+        XCTAssertEqual(entries[1].commits.map { $0.ticket?.key }, ["SDK-4142"])
+        XCTAssertEqual(entries[2].board, nil)
+        XCTAssertEqual(entries[2].commits.map { $0.message }, ["Merge remote-tracking branch 'origin/release/babylon/4.4.0' into develop"])
+        XCTAssertEqual(entries[2].commits.map { $0.ticket?.key }, [nil])
 
         let jiraBaseURL = URL(string: "https://babylonpartners.atlassian.net:443")!
         let changelogDoc = JiraService.document(from: entries, jiraBaseURL: jiraBaseURL)
@@ -223,7 +229,64 @@ extension AppTests {
                             {
                               "type" : "inlineCard",
                               "attrs" : {
+                                "url" : "https:\/\/babylonpartners.atlassian.net:443\/browse\/CNSMR-1763#icft=CNSMR-1763"
+                              }
+                            },
+                            {
+                              "type" : "text",
+                              "text" : " Migrate sdk-nhsgp into sdk-core (#8163)"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type" : "listItem",
+                      "content" : [
+                        {
+                          "type" : "paragraph",
+                          "content" : [
+                            {
+                              "type" : "inlineCard",
+                              "attrs" : {
                                 "url" : "https:\/\/babylonpartners.atlassian.net:443\/browse\/CNSMR-2045#icft=CNSMR-2045"
+                              }
+                            },
+                            {
+                              "type" : "text",
+                              "text" : " Commit 3"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type" : "heading",
+                  "attrs" : {
+                    "level" : 3
+                  },
+                  "content" : [
+                    {
+                      "type" : "text",
+                      "text" : "SDK tickets"
+                    }
+                  ]
+                },
+                {
+                  "type" : "bulletList",
+                  "content" : [
+                    {
+                      "type" : "listItem",
+                      "content" : [
+                        {
+                          "type" : "paragraph",
+                          "content" : [
+                            {
+                              "type" : "inlineCard",
+                              "attrs" : {
+                                "url" : "https:\/\/babylonpartners.atlassian.net:443\/browse\/SDK-4142#icft=SDK-4142"
                               }
                             },
                             {
@@ -244,7 +307,7 @@ extension AppTests {
                   "content" : [
                     {
                       "type" : "text",
-                      "text" : "CRP tickets"
+                      "text" : "Other"
                     }
                   ]
                 },
@@ -258,34 +321,8 @@ extension AppTests {
                           "type" : "paragraph",
                           "content" : [
                             {
-                              "type" : "inlineCard",
-                              "attrs" : {
-                                "url" : "https:\/\/babylonpartners.atlassian.net:443\/browse\/CRP-4141#icft=CRP-4141"
-                              }
-                            },
-                            {
                               "type" : "text",
-                              "text" : " Commit 3"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "type" : "listItem",
-                      "content" : [
-                        {
-                          "type" : "paragraph",
-                          "content" : [
-                            {
-                              "type" : "inlineCard",
-                              "attrs" : {
-                                "url" : "https:\/\/babylonpartners.atlassian.net:443\/browse\/CRP-4142#icft=CRP-4142"
-                              }
-                            },
-                            {
-                              "type" : "text",
-                              "text" : " Commit 4"
+                              "text" : "Merge remote-tracking branch 'origin\/release\/babylon\/4.4.0' into develop"
                             }
                           ]
                         }


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/CNSMR-2692

### Why?

* The regex used to extract JIRA ticket references from commit messages was buggy, allowing to match any text in the form `[a-z]*-[0-9]*`, meaning that it erroneously matched text like `remote-tracking` as a jira ticket from (non-existing) board `REMOTE` and lacking a ticket number, because *the regex allowed a match of size zero* for either part.

* Additionally, we realised that the `TES` board also had to be blacklisted because similarly to MN and IDM, it was not configured like the other boards and the `Fix Version` field for this board was configured to be hidden and disabled.

See [this slack message](https://babylonhealth.slack.com/archives/CJJ54RDFT/p1566411007003300) for the problem in action.
![image](https://user-images.githubusercontent.com/216089/63556661-fed07380-c545-11e9-90a9-358423db279a.png)

### How?

* Added the false positives examples to Unit Tests
* Fixed the regex to make sure we have at least one character and at least one digit in the ticket reference (instead of allowing zero occurrences), to make the new test cases pass.
* Removed `TES` board from the whitelist until board config is fixed
* Updated [CNSMR-2402](https://babylonpartners.atlassian.net/browse/CNSMR-2402) to add `TES` to the list of boards to re-activate one day if/when said board's configuration is fixed.

### PR checklist

* [x] I've assigned this PR to myself

With :heart:
