### PR TITLE
Ilya/ci21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ workflows:
   version: 2
 
   build:
+    when: << pipeline.parameters.push >>
     jobs: 
       - linux
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,21 @@ parameters:
     default: false
   push:
     type: boolean
-    default: true 
+    default: true
+  swift:
+    type: enum
+    enum: ["build", "test"]
+    default: "build"
 
 jobs:
-  
+  swift:
+    docker:
+      - image: vapor/swift:5.0.0
+    steps:
+      - checkout
+      - run: apt-get update; apt-get install -y libssl-dev zlib1g-dev
+      - run: swift << pipeline.parameters.swift >> 
+
   linux:
     docker:
       - image: vapor/swift:5.0.0
@@ -35,6 +46,11 @@ jobs:
 
 workflows:
   version: 2
+
+  swift:
+    when: << pipeline.parameters.swift >>
+    jobs:
+      - swift
 
   build:
     when: << pipeline.parameters.push >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ parameters:
     default: false
 
 jobs:
-  linux:
+  linux-build:
     docker:
       - image: vapor/swift:5.0.0
     steps:
@@ -39,8 +39,10 @@ workflows:
   test:
     when: << pipeline.parameters.run_tests >>
     jobs:
+      - linux-build
       - linux-test
 
   build_release:
     jobs:
+      - linux-build
       - linux-release 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ parameters:
   release:
     type: boolean
     default: false
+  build:
+    type: boolean
+    default: false
 
 jobs:
   linux-build:
@@ -43,6 +46,7 @@ workflows:
       - linux-test
 
   build_release:
+    when: << pipeline.parameters.build >>
     jobs:
       - linux-build
       - linux-release 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,7 @@ parameters:
   run_tests:
     type: boolean
     default: false
-  release:
-    type: boolean
-    default: false
-  build:
+  build_release:
     type: boolean
     default: false
 
@@ -40,13 +37,17 @@ jobs:
 workflows:
   version: 2
 
+  build:
+    jobs:
+      - linux-build
+
   test:
     when: << pipeline.parameters.run_tests >>
     jobs:
       - linux-test
 
   build_release:
-    when: << pipeline.parameters.build >>
+    when: << pipeline.parameters.build_release >>
     jobs:
       - linux-build
       - linux-release 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,13 @@
 version: 2.1
 
+parameters:
+  run_tests:
+    type: boolean
+    default: false
+  release:
+    type: boolean
+    default: false
+
 jobs:
   linux:
     docker:
@@ -8,7 +16,14 @@ jobs:
       - checkout
       - run: apt-get update; apt-get install -y libssl-dev zlib1g-dev
       - run: swift build
-      - run: swift test
+
+  linux-test:
+    docker:
+      - image: vapor/swift:5.0.0
+    steps:
+      - checkout
+      - run: apt-get update; apt-get install -y libssl-dev zlib1g-dev
+      - run: swift test 
 
   linux-release:
     docker:
@@ -20,20 +35,12 @@ jobs:
 
 workflows:
   version: 2
-  tests:
-    jobs:
-      - linux
-      - linux-release
 
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
+  test:
+    when: << pipeline.parameters.run_tests >>
     jobs:
-      - linux
-      - linux-release
-      
+      - linux-test
+
+  build_release:
+    jobs:
+      - linux-release 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,10 +14,6 @@ parameters:
 jobs:
   
   linux:
-    parameters:
-      run_tests:
-        type: boolean
-        default: false
     docker:
       - image: vapor/swift:5.0.0
     steps:
@@ -25,7 +21,7 @@ jobs:
       - run: apt-get update; apt-get install -y libssl-dev zlib1g-dev
       - run: swift build
       - when:
-          condition: << parameters.run_tests >>
+          condition: << pipeline.parameters.run_tests >>
           steps:
             - run: swift test 
 
@@ -42,8 +38,7 @@ workflows:
 
   build:
     jobs: 
-      - linux:
-          run_tests: << pipeline.parameters.run_tests >>
+      - linux
 
   build_release:
     when: << pipeline.parameters.build_release >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
     steps:
       - checkout
       - run: apt-get update; apt-get install -y libssl-dev zlib1g-dev
+      - run: swift build
       - run: swift test 
 
   linux-release:
@@ -42,7 +43,6 @@ workflows:
   test:
     when: << pipeline.parameters.run_tests >>
     jobs:
-      - linux-build
       - linux-test
 
   build_release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,13 @@ parameters:
     default: false
 
 jobs:
+  
+  dummy:
+    docker:
+      - image: vapor/swift:5.0.0
+    steps:
+      - run: echo "I do nothing" 
+   
   linux-build:
     docker:
       - image: vapor/swift:5.0.0
@@ -37,9 +44,9 @@ jobs:
 workflows:
   version: 2
 
-  build:
-    jobs:
-      - linux-build
+  dummy:
+    jobs: 
+      - dummy
 
   test:
     when: << pipeline.parameters.run_tests >>
@@ -49,5 +56,4 @@ workflows:
   build_release:
     when: << pipeline.parameters.build_release >>
     jobs:
-      - linux-build
       - linux-release 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,15 +7,12 @@ parameters:
   build_release:
     type: boolean
     default: false
+  push:
+    type: boolean
+    default: true 
 
 jobs:
   
-  dummy:
-    docker:
-      - image: vapor/swift:5.0.0
-    steps:
-      - run: echo "I do nothing" 
-   
   linux-build:
     docker:
       - image: vapor/swift:5.0.0
@@ -44,9 +41,10 @@ jobs:
 workflows:
   version: 2
 
-  dummy:
+  build:
+    when: << pipeline.parameters.push >>
     jobs: 
-      - dummy
+      - linux-build
 
   test:
     when: << pipeline.parameters.run_tests >>
@@ -57,3 +55,4 @@ workflows:
     when: << pipeline.parameters.build_release >>
     jobs:
       - linux-release 
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,16 @@ parameters:
     enum: ["build", "test"]
     default: "build"
 
+commands:
+  swift:
+    description: "Runs swift command"
+    parameters:
+      command:
+        default: --version
+        type: string
+    steps:
+      - run: swift << parameters.command >>
+
 jobs:
   swift:
     docker:
@@ -22,7 +32,8 @@ jobs:
     steps:
       - checkout
       - run: apt-get update; apt-get install -y libssl-dev zlib1g-dev
-      - run: swift << pipeline.parameters.swift >> 
+      - swift:
+          command: << pipeline.parameters.swift >>  
 
   linux:
     docker:
@@ -30,11 +41,13 @@ jobs:
     steps:
       - checkout
       - run: apt-get update; apt-get install -y libssl-dev zlib1g-dev
-      - run: swift build
+      - swift:
+          command: build  
       - when:
           condition: << pipeline.parameters.run_tests >>
           steps:
-            - run: swift test 
+            - swift:
+                command: test  
 
   linux-release:
     docker:
@@ -42,13 +55,14 @@ jobs:
     steps:
       - checkout
       - run: apt-get update; apt-get install -y libssl-dev zlib1g-dev
-      - run: swift build -c release
+      - swift:
+          command: build -c release
 
 workflows:
   version: 2
 
   swift:
-    when: << pipeline.parameters.swift >>
+    unless: << pipeline.parameters.push >>
     jobs:
       - swift
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,22 +13,21 @@ parameters:
 
 jobs:
   
-  linux-build:
+  linux:
+    parameters:
+      run_tests:
+        type: boolean
+        default: false
     docker:
       - image: vapor/swift:5.0.0
     steps:
       - checkout
       - run: apt-get update; apt-get install -y libssl-dev zlib1g-dev
       - run: swift build
-
-  linux-test:
-    docker:
-      - image: vapor/swift:5.0.0
-    steps:
-      - checkout
-      - run: apt-get update; apt-get install -y libssl-dev zlib1g-dev
-      - run: swift build
-      - run: swift test 
+      - when:
+          condition: << parameters.run_tests >>
+          steps:
+            - run: swift test 
 
   linux-release:
     docker:
@@ -42,14 +41,9 @@ workflows:
   version: 2
 
   build:
-    when: << pipeline.parameters.push >>
     jobs: 
-      - linux-build
-
-  test:
-    when: << pipeline.parameters.run_tests >>
-    jobs:
-      - linux-test
+      - linux:
+          run_tests: << pipeline.parameters.run_tests >>
 
   build_release:
     when: << pipeline.parameters.build_release >>


### PR DESCRIPTION
This PR is not intended for merge rather than just for trying out new configuration options.

### Why?
To try out CircleCI 2.1 features

### How?
This PR demonstrations conditional workflows and conditional jobs.

To trigger specific workflow we need to define pipeline parameter (on top level) and use it in workflow with `when` key. Then it can be triggered with API call like `curl -u ${CIRCLECI_TOKEN}: -X POST "Content-Type: application/json" -H 'Content-Type: application/json' -H 'Accept: application/json' -d '{"branch":"ilya/ci21", "parameters": {"build_release": true}}' https://circleci.com/api/v2/project/github/Babylonpartners/Stevenson/pipeline`

We can also use pipeline parameters in the jobs steps so that we can skip some steps. I.e. `curl -u ${CIRCLECI_TOKEN}: -X POST "Content-Type: application/json" -H 'Content-Type: application/json' -H 'Accept: application/json' -d '{"branch":"ilya/ci21", "parameters": {"run_tests": true}}' https://circleci.com/api/v2/project/github/Babylonpartners/Stevenson/pipeline` will build and run tests, but without `run_tests` parameter (on push) it will not run tests.

With parameter `push` which default set to `true` we can define what workflow to run when code is being pushed to the branch. When workflow is triggered via api call this parameter should be passed with `false`. This is done so because if we have a workflow without any conditions then it will be also run on each API call. If we remove such workflow then on pushes we will get an error because config will not contain any workflows. For that reason we can't really not do anything on pushes but we can control what exactly we do, i.e. only run some fast checks and not build the project, which takes most of the CI time.

As a result with 2.1 configuration we can:

- [x] trigger workflows via API calls
- [x] conditionally run steps in the workflows
- [x] pass parameters via API call

### PR checklist

* [x] I've assigned this PR to myself

With :heart: