### PR TITLE
Add original command to the response

### DIFF
--- a/Sources/App/Fastlane/SlackCommand+Fastlane.swift
+++ b/Sources/App/Fastlane/SlackCommand+Fastlane.swift
@@ -107,6 +107,7 @@ extension SlackCommand {
             )
             .map {
                 SlackResponse("""
+                    You asked me: `\(metadata.text)`.
                     🚀 Triggered `\(lane)` on the `\($0.branch)` branch.
                     \($0.buildURL)
                     """,


### PR DESCRIPTION
### Why?
Sometimes our bot times out. In this case the message to trigger the command is being replaced with the error message.

### How?
Add original message to the response so that we always have it

### PR checklist

* [x] I've assigned this PR to myself

With :heart: