### PR TITLE
CNSMR-2877: Whitelist the new Monitor Squad board

### DIFF
--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -1,6 +1,7 @@
 import Vapor
 import Stevenson
 
+// Use https://babylonpartners.atlassian.net/rest/api/3/project/<ProjectKey> to get the corresponding ID
 private let jiraProjects = [
     "APPTS" : 16875, // Booking/Appointments
     "AV"    : 16942, // Core Experience / Avalon
@@ -11,9 +12,9 @@ private let jiraProjects = [
     "COREUS": 17127, // Babylon US Core Product
     "CW"    : 16832, // Consumer Web
     "GW"    : 16949, // Triage UI
-    // TODO: [CNSMR-2402] Re-enable IDM and MN once those boards have migrated to use the standard setup for their JIRA fields
+    // TODO: [CNSMR-2402] Re-enable IDM once this board have migrated to use the standard setup for their JIRA fields
     // "IDM"   : 16903, // Identity Platform / Identity Management
-    // "MN"    : 17031, // Monitor
+    "MS"    : 17233, // Monitor Squad
     "MON"   : 10103, // HealthCheck
     "NRX"   : 16911, // Enrolment and Integrity
     "PAR"   : 17098, // Partnerships
@@ -21,7 +22,7 @@ private let jiraProjects = [
     "PRSCR" : 16840, // Prescriptions
     "SDK"   : 16975, // SDK
     "TEL"   : 16857, // Telus
-    // TODO: [CNSMR-2402] Re-enable TES once this boards have migrated to use the standard setup for their JIRA fields
+    // TODO: [CNSMR-2402] Re-enable TES once this board have migrated to use the standard setup for their JIRA fields
     // "TES"   : 17074, // Test Kits
     "WH"    : 17112, // Women's Health
 ]


### PR DESCRIPTION
Tickets:
 - https://babylonpartners.atlassian.net/browse/CNSMR-2402 (parent)
 - https://babylonpartners.atlassian.net/browse/CNSMR-2877 (specific to Monitor)

### Why?

The Monitor squad was previously using a JIRA board (`MN`) which didn't fit the configuration we use for all the other boards, making it incompatible with our CRP Bot, forcing us to remove it from our whitelist.

But recently the monitor squad has switched to a new JIRA board (`MS`) which supposedly now uses the same settings as the other boards and should be compatible with the bot.

### How?

Added this new `MS` board in our whitelist so that invocations of `/crp` now also handle `MS-xxx` tickets (set their Fixed Version and all on release cut)

### PR checklist

* [x] I've assigned this PR to myself

With :heart:
