### PR TITLE
CNSMR-2878: Assign Mark Bates instead of Andreea for CRP tickets

### DIFF
--- a/Sources/App/CRP/JiraService+CRP.swift
+++ b/Sources/App/CRP/JiraService+CRP.swift
@@ -10,7 +10,8 @@ extension JiraService {
     ) -> CRPIssue {
         // [CNSMR-1319] TODO: Use a config file to parametrise accountable person
         let isTelus = release.appName.caseInsensitiveCompare("Telus") == .orderedSame
-        let accountablePerson = isTelus ? "ryan.covill" : "andreea.papillon"
+        // Ensure to use a valid username key, check with https://babylonpartners.atlassian.net/rest/api/3/user?username=<name>
+        let accountablePerson = isTelus ? "ryan.covill" : "mark.bates"
         let changelog = changelog
         let fields = CRPIssueFields(
             jiraBaseURL: jiraBaseURL,

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -353,7 +353,7 @@ extension AppTests {
             },
             "customfield_12541" : "https:\/\/github.com\/company\/project\/releases\/tag\/app\/1.2.3",
             "customfield_11505" : {
-              "name" : "andreea.papillon"
+              "name" : "mark.bates"
             }
           }
         }


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/CNSMR-2878

### Why?

Andreea asked to be replaced by Mark Bates as accountable person for all CRP tickets except Telus

### How?

Update the username in the code from Andreea to Mark

### PR checklist

* [x] I've assigned this PR to myself

With :heart:
