### PR TITLE
[CNSMR-2888] Migrate slack command from hockeyapp to appcenter

### DIFF
--- a/Sources/App/Fastlane/SlackCommand+Fastlane.swift
+++ b/Sources/App/Fastlane/SlackCommand+Fastlane.swift
@@ -58,18 +58,18 @@ extension SlackCommand {
         })
     }
 
-    static let hockeyapp = { (ci: CircleCIService) in
+    static let appcenter = { (ci: CircleCIService) in
         SlackCommand(
-            name: "hockeyapp",
+            name: "appcenter",
             help: """
-            Makes a new beta build for HockeyApp. Shorthand for `/fastlane hockeyapp`.
+            Makes a new beta build for AppCenter. Shorthand for `/fastlane appcenter`.
 
             Parameters:
             - name of the target (as in the project)
             - `branch`: name of the branch to run the lane on. Default is `\(RepoMapping.ios.repository.baseBranch)`
 
             Example:
-            `/hockeyapp Babylon \(Option.branch.value):develop`
+            `/appcenter Babylon \(Option.branch.value):develop`
             """,
             allowedChannels: ["ios-build"],
             run: { metadata, container in
@@ -77,7 +77,7 @@ extension SlackCommand {
                     metadata: SlackCommandMetadata(
                         token: metadata.token,
                         channelName: metadata.channelName,
-                        text: "hockeyapp target:\(metadata.text)",
+                        text: "appcenter target:\(metadata.text)",
                         responseURL: metadata.responseURL
                     ),
                     ci: ci,

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -51,7 +51,7 @@ public func configure(_ config: inout Config, _ env: inout Environment, _ servic
     let router = EngineRouter.default()
     try routes(router: router, slack: slack, commands: [
         .fastlane(ci),
-        .hockeyapp(ci),
+        .appcenter(ci),
         .testflight(ci),
         .crp(jira, github)
     ])


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/CNSMR-2888
Fastlane changes PR for reference: https://github.com/Babylonpartners/babylon-ios/pull/8899

**Important notes:**
* Deployment of this change has to be synchronized with a change of our Slack Commands, see [JIRA ticket](https://babylonpartners.atlassian.net/browse/CNSMR-2890).
* This change shouldn't be deployed before merging https://github.com/Babylonpartners/babylon-ios/pull/8899.

### Why?
HockeyApp is shutting down so we need to migrate to the App Center.

### How?
* Rename `hockeyapp` to `appcenter` for consistency.

### PR checklist

* [x] I've assigned this PR to myself

With :heart: