### PR TITLE
[CNSMR-2952] Trigger CircleCI 2.1 pipelines instead of individual jobs

### DIFF
--- a/Sources/App/Fastlane/SlackCommand+Fastlane.swift
+++ b/Sources/App/Fastlane/SlackCommand+Fastlane.swift
@@ -48,6 +48,7 @@ extension SlackCommand {
                     metadata: SlackCommandMetadata(
                         token: metadata.token,
                         channelName: metadata.channelName,
+                        command: "/",
                         text: "testflight target:\(metadata.text)",
                         responseURL: metadata.responseURL
                     ),
@@ -77,6 +78,7 @@ extension SlackCommand {
                     metadata: SlackCommandMetadata(
                         token: metadata.token,
                         channelName: metadata.channelName,
+                        command: "/",
                         text: "hockeyapp target:\(metadata.text)",
                         responseURL: metadata.responseURL
                     ),
@@ -96,14 +98,14 @@ extension SlackCommand {
         let options = metadata.textComponents.dropFirst().joined(separator: " ")
         let branch = branch ?? metadata.value(forOption: .branch)
 
-        let parameters: [String: CircleCIService.BuildRequest.Parameter] = [
+        let parameters: [String: CircleCIService.PipelineRequest.Parameter] = [
             "push": .bool(false),
             "lane": .string(lane),
             "options": .string(options)
         ]
 
         return try ci
-            .run(
+            .pipeline(
                 parameters: parameters,
                 project: RepoMapping.ios.repository.fullName,
                 branch: branch ?? RepoMapping.ios.repository.baseBranch,
@@ -111,7 +113,7 @@ extension SlackCommand {
             )
             .map {
                 SlackResponse("""
-                    You asked me: `\(metadata.text)`.
+                    You asked me: `\(metadata.command) \(metadata.text)`.
                     🚀 Triggered `\(lane)` on the `\($0.branch)` branch.
                     \($0.buildURL)
                     """,

--- a/Sources/App/Fastlane/SlackCommand+Fastlane.swift
+++ b/Sources/App/Fastlane/SlackCommand+Fastlane.swift
@@ -48,7 +48,7 @@ extension SlackCommand {
                     metadata: SlackCommandMetadata(
                         token: metadata.token,
                         channelName: metadata.channelName,
-                        command: "/",
+                        command: "/fastlane",
                         text: "testflight target:\(metadata.text)",
                         responseURL: metadata.responseURL
                     ),
@@ -78,7 +78,7 @@ extension SlackCommand {
                     metadata: SlackCommandMetadata(
                         token: metadata.token,
                         channelName: metadata.channelName,
-                        command: "/",
+                        command: "/fastlane",
                         text: "hockeyapp target:\(metadata.text)",
                         responseURL: metadata.responseURL
                     ),

--- a/Sources/App/Fastlane/SlackCommand+Fastlane.swift
+++ b/Sources/App/Fastlane/SlackCommand+Fastlane.swift
@@ -96,8 +96,12 @@ extension SlackCommand {
         let options = metadata.textComponents.dropFirst().joined(separator: " ")
         let branch = branch ?? metadata.value(forOption: .branch)
 
-        let parameters = ["FASTLANE": lane, "OPTIONS": options]
-        
+        let parameters: [String: CircleCIService.BuildRequest.Parameter] = [
+            "push": .bool(false),
+            "lane": .string(lane),
+            "options": .string(options)
+        ]
+
         return try ci
             .run(
                 parameters: parameters,

--- a/Sources/Stevenson/CircleCIService.swift
+++ b/Sources/Stevenson/CircleCIService.swift
@@ -128,9 +128,11 @@ extension CircleCIService {
             try container.client().post(url, headers: headers) {
                 try $0.content.encode(json: PipelineRequest(branch: branch, parameters: parameters))
             }
-        }.flatMap { (pipelineID: PipelineID) in
+        }.map { (pipelineID: PipelineID) in
+            self.pipelineURL(pipelineID: pipelineID.id)
+        }.flatMap { pipelineURL in
             try self.request(.capture()) {
-                try container.client().get(self.pipelineURL(pipelineID: pipelineID.id), headers: self.headers)
+                try container.client().get(pipelineURL, headers: self.headers)
             }
         }.map { (pipeline: Pipeline) in
             PipelineResponse(

--- a/Sources/Stevenson/CircleCIService.swift
+++ b/Sources/Stevenson/CircleCIService.swift
@@ -13,42 +13,92 @@ public struct CircleCIService {
         self.token = token
     }
 
-    struct BuildRequest: Content {
-        let buildParameters: [String: String]
+    public struct BuildRequest: Encodable {
+        let branch: String
+        let parameters: [String: Parameter]
 
-        enum CodingKeys: String, CodingKey {
-            case buildParameters = "build_parameters"
+        public enum Parameter: Encodable {
+            case bool(Bool)
+            case string(String)
+
+            public func encode(to encoder: Encoder) throws {
+                var values = encoder.singleValueContainer()
+                switch self {
+                case let .bool(value):
+                    try values.encode(value)
+                case let .string(value):
+                    try values.encode(value)
+                }
+            }
         }
     }
 
     public struct BuildResponse: Content {
         public let branch: String
-        public let buildURL: String
+        public let buildURL: URL
+    }
 
-        enum CodingKeys: String, CodingKey {
-            case branch
-            case buildURL = "build_url"
+    struct PipelineID: Content {
+        let id: String
+    }
+
+    struct Pipeline: Content {
+        let workflows: [Workflow]
+        let vcs: VCS
+
+        struct Workflow: Content {
+            let id: String
+        }
+
+        struct VCS: Content {
+            let branch: String
         }
     }
 
     private func buildURL(project: String, branch: String) -> URL {
         return URL(
-            string: "/api/v1.1/project/github/\(project)/tree/\(branch)?circle-token=\(token)",
+            string: "/api/v2/project/github/\(project)/pipeline?circle-token=\(token)",
+            relativeTo: baseURL
+        )!
+    }
+
+    private func pipelineURL(pipelineID: String) -> URL {
+        return URL(
+            string: "/api/v2/pipeline/\(pipelineID)?circle-token=\(token)",
+            relativeTo: baseURL
+        )!
+    }
+
+    private func workflowURL(workflowID: String) -> URL {
+        return URL(
+            string: "/workflow-run/\(workflowID)",
             relativeTo: baseURL
         )!
     }
 
     public func run(
-        parameters: [String: String],
+        parameters: [String: BuildRequest.Parameter],
         project: String,
         branch: String,
         on container: Container
     ) throws -> Future<BuildResponse> {
         let url = buildURL(project: project, branch: branch)
+
         return try request(.capture()) {
             try container.client().post(url, headers: headers) {
-                try $0.content.encode(BuildRequest(buildParameters: parameters))
+                try $0.content.encode(json: BuildRequest(branch: branch, parameters: parameters))
             }
+        }.flatMap { (pipelineID: PipelineID) in
+            try self.request(.capture()) {
+                try container.client().get(self.pipelineURL(pipelineID: pipelineID.id), headers: self.headers)
+            }
+        }.map { (pipeline: Pipeline) in
+            BuildResponse(
+                branch: pipeline.vcs.branch,
+                buildURL: pipeline.workflows.first.map {
+                    self.workflowURL(workflowID: $0.id)
+                } ?? self.baseURL
+            )
         }
     }
 }

--- a/Sources/Stevenson/SlackService.swift
+++ b/Sources/Stevenson/SlackService.swift
@@ -29,6 +29,7 @@ public struct SlackCommand {
 public struct SlackCommandMetadata: Content {
     public let token: String
     public let channelName: String
+    public let command: String
     public let text: String
     public let textComponents: [String.SubSequence]
     public let responseURL: String?
@@ -36,11 +37,13 @@ public struct SlackCommandMetadata: Content {
     public init(
         token: String,
         channelName: String,
+        command: String,
         text: String,
         responseURL: String?
     ) {
         self.token = token
         self.channelName = channelName
+        self.command = command
         self.text = text
         self.textComponents = text.split(separator: " ")
         self.responseURL = responseURL
@@ -49,6 +52,7 @@ public struct SlackCommandMetadata: Content {
     enum CodingKeys: String, CodingKey {
         case token
         case channelName = "channel_name"
+        case command
         case text
         case responseURL = "response_url"
     }
@@ -58,6 +62,7 @@ public struct SlackCommandMetadata: Content {
         self = try SlackCommandMetadata(
             token:          container.decode(String.self, forKey: .token),
             channelName:    container.decode(String.self, forKey: .channelName),
+            command:        container.decode(String.self, forKey: .command),
             text:           container.decode(String.self, forKey: .text),
             responseURL:    container.decode(String.self, forKey: .responseURL)
         )


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/CNSMR-2952

### Why?
CircleCI 2.1 adds a new API to trigger workflows (pipelines) via API.
https://github.com/CircleCI-Public/api-preview-docs/blob/master/docs/api-changes.md

### How?
Add new method to trigger pipeline that works with new APIs. Instead of triggering individual jobs commands now trigger pipelines. For `fastlane` command the effect is only that instead of a sing job a workflow with a single job will be triggered. But for other commands we can trigger more complicated workflows (and even multiple workflows) which will be able to run multiple jobs in parallel.

### PR checklist

* [x] I've assigned this PR to myself

With :heart: