### PR TITLE
[IOSP-121] Use one main slack command

### DIFF
--- a/Sources/App/Fastlane/SlackCommand+Fastlane.swift
+++ b/Sources/App/Fastlane/SlackCommand+Fastlane.swift
@@ -3,35 +3,6 @@ import Vapor
 import Stevenson
 
 extension SlackCommand {
-    static let stevenson = { (ci: CircleCIService) in
-        SlackCommand(
-            name: "stevenson",
-            help: """
-            Invokes lane, beta or AppStore build or runs arbitrary workflow.
-
-            Parameters:
-            - name of the workflow to run
-            - list of workflow parameters in the fastlane format (e.g. `param:value`)
-            - `branch`: name of the branch to run the lane on. Default is `\(RepoMapping.ios.repository.baseBranch)`
-
-            Example:
-            `/stevenson ui_tests param:value \(Option.branch.value):develop`
-            """,
-            allowedChannels: [],
-            subCommands: [
-                SlackCommand.fastlane(ci),
-                SlackCommand.testflight(ci),
-                SlackCommand.hockeyapp(ci)
-            ],
-            run: { metadata, container in
-                try runPipeline(
-                    metadata: metadata,
-                    ci: ci,
-                    on: container
-                )
-        })
-    }
-
     static let fastlane = { (ci: CircleCIService) in
         SlackCommand(
             name: "fastlane",

--- a/Sources/App/Fastlane/SlackCommand+Fastlane.swift
+++ b/Sources/App/Fastlane/SlackCommand+Fastlane.swift
@@ -106,7 +106,7 @@ extension SlackCommand {
                     return nil
                 }
         }
-        var parameters = Dictionary(uniqueKeysWithValues: optionsKeysValues)
+        var parameters = Dictionary(optionsKeysValues, uniquingKeysWith: { $1 })
         parameters["push"] = .bool(false)
         parameters[pipeline] = .bool(true)
 

--- a/Sources/App/MainCommand.swift
+++ b/Sources/App/MainCommand.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Vapor
+import Stevenson
+
+extension SlackCommand {
+    static let stevenson = { (ci: CircleCIService, jira: JiraService, github: GitHubService) in
+        SlackCommand(
+            name: "stevenson",
+            help: """
+            Invokes lane, beta or AppStore build or runs arbitrary workflow.
+
+            Parameters:
+            - name of the workflow or sub command to run
+            - list of workflow or sub command parameters in the fastlane format (e.g. `param:value`)
+            - `branch`: name of the branch to run the lane on. Default is `\(RepoMapping.ios.repository.baseBranch)`
+
+            Example:
+            `/stevenson ui_tests param:value \(Option.branch.value):develop`
+            """,
+            allowedChannels: [],
+            subCommands: [
+                .fastlane(ci),
+                .testflight(ci),
+                .hockeyapp(ci),
+                .crp(jira, github)
+            ],
+            run: { metadata, container in
+                try runPipeline(
+                    metadata: metadata,
+                    ci: ci,
+                    on: container
+                )
+        })
+    }
+}

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -51,8 +51,7 @@ public func configure(_ config: inout Config, _ env: inout Environment, _ servic
 
     let router = EngineRouter.default()
     try routes(router: router, slack: slack, commands: [
-        .stevenson(ci),
-        .crp(jira, github)
+        .stevenson(ci, jira, github)
     ])
     services.register(router, as: Router.self)
 

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -51,9 +51,7 @@ public func configure(_ config: inout Config, _ env: inout Environment, _ servic
 
     let router = EngineRouter.default()
     try routes(router: router, slack: slack, commands: [
-        .fastlane(ci),
-        .hockeyapp(ci),
-        .testflight(ci),
+        .stevenson(ci),
         .crp(jira, github)
     ])
     services.register(router, as: Router.self)

--- a/Sources/Stevenson/SlackService.swift
+++ b/Sources/Stevenson/SlackService.swift
@@ -11,7 +11,7 @@ public struct SlackCommand {
     /// If empty the command will be allowed in all channels
     public let allowedChannels: Set<String>
 
-    let run: (SlackCommandMetadata, Request) throws -> Future<SlackResponse>
+    public let run: (SlackCommandMetadata, Request) throws -> Future<SlackResponse>
 
     public init(
         name: String,

--- a/Sources/Stevenson/SlackService.swift
+++ b/Sources/Stevenson/SlackService.swift
@@ -12,7 +12,7 @@ public struct SlackCommand {
     public let allowedChannels: Set<String>
 
     /// Closure that performs the actual action of the command.
-    /// If subCommands are provided then it first will try to select approapraite sub command
+    /// If subCommands are provided, it will first try to select the appropriate sub-command
     /// by the first word in the command text, and if it finds one then this command will be executed,
     /// otherwise this closure is called
     public let run: (SlackCommandMetadata, Request) throws -> Future<SlackResponse>

--- a/Sources/Stevenson/SlackService.swift
+++ b/Sources/Stevenson/SlackService.swift
@@ -33,6 +33,8 @@ public struct SlackCommand {
             """
             Sub-commands:
             \(subCommands.map({ "- \($0.name)" }).joined(separator: "\n"))
+            
+            Run `/(name) <sub-command> help` for help on a sub-command.
             """
         }
         self.run = { (metadata, container) throws -> Future<SlackResponse> in


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/IOSP-121

### Why?
<!--- Why this change is needed --->

### How?

Instead of individual tasks create one task that redirects to one of them. With that we will write `/stevenson fastlane target:Babylon version:x.y.x` instead of `/fastlane target:Babylon version:x.y.z`. It will be also possible to write `/stevenson help` or `/stevenson fastlane help` to get more detailed instructions on specific command. 

It will also be possible to implement this command in a dynamic way so that it can provide suggesting for what to run like fatslane does if you don't provide lane name (though I didn't explore that yet).

### PR checklist

* [x] I've assigned this PR to myself

With :heart:
