### PR TITLE
[IOSP-194] Add IOSP and ANDRP projects to whitelist

### DIFF
--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -3,6 +3,7 @@ import Stevenson
 
 // Use https://babylonpartners.atlassian.net/rest/api/3/project/<ProjectKey> to get the corresponding ID
 private let jiraProjects = [
+    "ANDRP" : 17264, // Android Platform
     "APPTS" : 16875, // Booking/Appointments
     "AV"    : 16942, // Core Experience / Avalon
     "CE"    : 16937, // Consultation Experience
@@ -14,6 +15,7 @@ private let jiraProjects = [
     "GW"    : 16949, // Triage UI
     // TODO: [CNSMR-2402] Re-enable IDM once this board have migrated to use the standard setup for their JIRA fields
     // "IDM"   : 16903, // Identity Platform / Identity Management
+    "IOSP"  : 17263, // iOS Platform Squad
     "MS"    : 17233, // Monitor Squad
     "MON"   : 10103, // HealthCheck
     "NRX"   : 16911, // Enrolment and Integrity


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/IOSP-194

### Why?

Now that iOS and Android Platform squads each have a dedicated board, we need to make the CRP bot also handle the tickets from those boards

### How?

Add them to the whitelist

### PR checklist

* [x] I've assigned this PR to myself

With :heart:
