### PR TITLE
[IOSP-233] Update links to new GitHub org name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 #  - The empty `iOS-PullAssigner` team will act as a proxy for the PullAssigner bot.
 #    When a new PR arrives, PullAssigner will be triggered, which will then pick members from the iOS-Admin team
 
-* @Babylonpartners/iOS-PullAssigner @Babylonpartners/ios-bot-owners
+* @babylonhealth/iOS-PullAssigner @babylonhealth/ios-bot-owners

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # iOS Build Distribution System
 
 `Stevenson` is a Vapor framework designed to build integrations between Slack apps, Github, JIRA and CI services (CircleCI).
-This project also contains implementation of the Slack app used by Babylon iOS team (if you want to know more about how our team works checkout our [playbook](https://github.com/Babylonpartners/ios-playbook))
+This project also contains implementation of the Slack app used by Babylon iOS team (if you want to know more about how our team works checkout our [playbook](https://github.com/babylonhealth/ios-playbook))
 
 ## 🚀 Usage
 
@@ -9,7 +9,7 @@ To use `Stevenson` in your app add it as a dependency to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/Babylonpartners/Stevenson.git", .branch("master")),
+    .package(url: "https://github.com/babylonhealth/Stevenson.git", .branch("master")),
 ]
 ```
 
@@ -184,7 +184,7 @@ Visit the Vapor web framework's [documentation](http://docs.vapor.codes) for ins
 
 ## ✨ Take a look at our other OSS projects!
 
-* [Bento](https://github.com/Babylonpartners/Bento): Swift library for building component-based interfaces on top of UITableView and UICollectionView 🍱
-* [DrawerKit](https://github.com/Babylonpartners/DrawerKit): DrawerKit lets an UIViewController modally present another UIViewController in a manner similar to the way Apple's Maps app works.
-* [ReactiveFeedback](https://github.com/Babylonpartners/ReactiveFeedback): Unidirectional reactive architecture
-* 🚧 [Wall-E](https://github.com/Babylonpartners/Wall-E): A bot that monitors and manages your pull requests by ensuring they are merged when they're ready and don't stack up in your repository 🤓
+* [Bento](https://github.com/babylonhealth/Bento): Swift library for building component-based interfaces on top of UITableView and UICollectionView 🍱
+* [DrawerKit](https://github.com/babylonhealth/DrawerKit): DrawerKit lets an UIViewController modally present another UIViewController in a manner similar to the way Apple's Maps app works.
+* [ReactiveFeedback](https://github.com/babylonhealth/ReactiveFeedback): Unidirectional reactive architecture
+* 🚧 [Wall-E](https://github.com/babylonhealth/Wall-E): A bot that monitors and manages your pull requests by ensuring they are merged when they're ready and don't stack up in your repository 🤓

--- a/Sources/App/RepoMapping.swift
+++ b/Sources/App/RepoMapping.swift
@@ -16,7 +16,7 @@ extension RepoMapping {
     // [CNSMR-1319] TODO: Use a config file to parametrise repo list
     static let ios = RepoMapping(
         repository: GitHubService.Repository(
-            fullName: "Babylonpartners/babylon-ios",
+            fullName: "babylonhealth/babylon-ios",
             baseBranch: "develop"
         ),
         crp: CRP(
@@ -37,7 +37,7 @@ extension RepoMapping {
 
     static let android = RepoMapping(
         repository: GitHubService.Repository(
-            fullName: "Babylonpartners/babylon-android",
+            fullName: "babylonhealth/babylon-android",
             baseBranch: "master"
         ),
         crp: CRP(


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/IOSP-233

### Why?
<!--- Why this change is needed --->

The Babylon GitHub org's name was changed from `Babylonpartners` to `babylonhealth`

### How?
<!--- Details about the implementation --->

Changing the old name to the new one

### PR checklist

* [x] I've assigned this PR to myself

With :heart:
