### PR TITLE
respond ok on all comment webhooks

### DIFF
--- a/Sources/App/GithubService+IssueComment.swift
+++ b/Sources/App/GithubService+IssueComment.swift
@@ -57,7 +57,8 @@ extension GitHubService {
                     action.repository.full_name == mapping.repository.fullName
                 })?.value.repository
             else {
-                throw Abort(.badRequest)
+                // fail command but still return ok code so that we don't have hooks reported as failed on github
+                throw Abort(.ok)
             }
 
             return try self.pullRequest(


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/<!--- Ticket number --->

### Why?
When comments are not addressed to bot we report hooks as failed though they were properly delivered. This may mask real issues, i.e. that the app is down.

### How?
Always return ok code

### PR checklist

* [x] I've assigned this PR to myself

With :heart:
