### PR TITLE
[IOSP-171] Add verbose logs to help debug CRP issues + use SlowClient for JIRA

### DIFF
--- a/Sources/App/CRP/JiraService+CRP.swift
+++ b/Sources/App/CRP/JiraService+CRP.swift
@@ -4,6 +4,7 @@ import Stevenson
 extension JiraService {
     static func makeCRPIssue(
         jiraBaseURL: URL,
+        crpProjectID: JiraService.FieldType.ObjectID,
         crpConfig: RepoMapping.CRP,
         release: GitHubService.Release,
         changelog: FieldType.TextArea.Document,
@@ -16,6 +17,7 @@ extension JiraService {
         let changelog = changelog
         let fields = CRPIssueFields(
             jiraBaseURL: jiraBaseURL,
+            crpProjectID: crpProjectID,
             summary: crpConfig.jiraSummary(release),
             environments: [crpConfig.environment],
             release: release,
@@ -35,8 +37,48 @@ extension JiraService {
     }
 }
 
+// MARK: - CRP Ticket Dance
 
-// MARK: - Define a CRP Issue
+extension JiraService {
+    /// Do the CRP ticket dance, which consists of:
+    ///  - creating the CRP ticket from list of commits,
+    ///  - then create all the JIRA versions on each boards,
+    ///  - then for each board, set the Fix Version field for each ticket concerned by the CRP for that board's JIRA version
+    internal func executeCRPTicketProcess(
+        crpProjectID: JiraService.FieldType.ObjectID = .init(id: "13402"), // CRP Project
+        release: GitHubService.Release,
+        repoMapping: RepoMapping,
+        commitMessages: [String],
+        container: Request
+    ) throws -> Future<(JiraService.CreatedIssue, JiraService.FixedVersionReport)> {
+
+        let jiraVersionName = repoMapping.crp.jiraVersionName(release)
+        let changelogSections = ChangelogSection.makeSections(from: commitMessages, for: release)
+
+        // Create CRP Issue
+        let crpIssue = JiraService.makeCRPIssue(
+            jiraBaseURL: self.baseURL,
+            crpProjectID: crpProjectID,
+            crpConfig: repoMapping.crp,
+            release: release,
+            changelog: self.document(from: changelogSections)
+        )
+
+        return try self.create(issue: crpIssue, on: container)
+            .catchError(.capture())
+            .flatMap { (crpIssue: JiraService.CreatedIssue) -> Future<(JiraService.CreatedIssue, JiraService.FixedVersionReport)> in
+                // Create JIRA versions on each board then set Fixed Versions to that new version on each board's ticket included in Changelog
+                let report = try self.createAndSetFixedVersions(
+                    changelogSections: changelogSections,
+                    versionName: jiraVersionName,
+                    on: container
+                )
+                return report.map { (crpIssue, $0) }
+        }
+    }
+}
+
+// MARK: - Define the CRP Issue type
 extension JiraService {
 
     /// A CRPIssue is a Jira issue specific to our CRP Board (aka Releases Plan Board)
@@ -69,7 +111,7 @@ extension JiraService {
 
         // MARK: Fields
 
-        var project = FieldType.ObjectID(id: "13402") // CRP Project
+        var project: FieldType.ObjectID
         var issueType = FieldType.ObjectID(id: "11439") // "CRP: Code Change Request"
         var summary: String
         var changelog: FieldType.TextArea.Document
@@ -87,7 +129,7 @@ extension JiraService {
         // MARK: Content keys
 
         enum CodingKeys: String, CodingKey {
-            case project = "project"
+            case project = "project"                     // required
             case issueType = "issuetype"                 // required
             case summary = "summary"                     // required
             case changelog = "customfield_12537"         // required
@@ -106,6 +148,7 @@ extension JiraService {
 
         init(
             jiraBaseURL: URL,
+            crpProjectID: FieldType.ObjectID,
             summary: String,
             environments: [Environment],
             release: GitHubService.Release,
@@ -114,6 +157,7 @@ extension JiraService {
             changelog: FieldType.TextArea.Document,
             accountablePersonName: String
         ) {
+            self.project = crpProjectID
             self.summary = summary
             self.changelog = changelog
             self.environments = environments
@@ -149,6 +193,7 @@ extension JiraService.CRPIssueFields.ReleaseType {
     }
 }
 
+// MARK: Create JIRA Documents
 extension JiraService {
     func document(from changelog: [ChangelogSection]) -> FieldType.TextArea.Document {
         return JiraService.document(from: changelog, jiraBaseURL: self.baseURL)
@@ -209,7 +254,7 @@ extension JiraService {
     }
 }
 
-// MARK: support for "Fixed Version"
+// MARK: Support for "Fixed Version"
 
 extension JiraService {
     /// Used to report non-fatal errors without failing the Future chain
@@ -249,7 +294,9 @@ extension JiraService {
                 )
                 return try self.createVersion(version, on: container)
                     .flatMap { try self.batchSetFixedVersions($0, tickets: project.tickets, on: container) }
-                    .mapIfError { FixedVersionReport("Error creating JIRA version in board \(project.key) - \($0)") }
+                    .mapIfError { error in
+                        return FixedVersionReport("Error creating JIRA version in board \(project.key) - \(error)")
+                    }
             }
             .map(to: FixedVersionReport.self, on: container, FixedVersionReport.init)
     }
@@ -259,7 +306,9 @@ extension JiraService {
             .map { (ticket: String) -> Future<FixedVersionReport> in
                 try self.setFixedVersion(version, for: ticket, on: container)
                     .map { _ in FixedVersionReport() }
-                    .mapIfError { FixedVersionReport("Error setting FixedVersion for \(ticket) - \($0)") }
+                    .mapIfError { error in
+                        return FixedVersionReport("Error setting FixedVersion for \(ticket) - \(error)")
+                }
             }
             .map(to: FixedVersionReport.self, on: container, FixedVersionReport.init)
     }

--- a/Sources/App/CRP/JiraService+CRP.swift
+++ b/Sources/App/CRP/JiraService+CRP.swift
@@ -45,10 +45,10 @@ extension JiraService {
     ///  - then create all the JIRA versions on each boards,
     ///  - then for each board, set the Fix Version field for each ticket concerned by the CRP for that board's JIRA version
     internal func executeCRPTicketProcess(
-        crpProjectID: JiraService.FieldType.ObjectID = .init(id: "13402"), // CRP Project
+        commitMessages: [String],
         release: GitHubService.Release,
         repoMapping: RepoMapping,
-        commitMessages: [String],
+        crpProjectID: JiraService.FieldType.ObjectID,
         container: Request
     ) throws -> Future<(JiraService.CreatedIssue, JiraService.FixedVersionReport)> {
 
@@ -68,12 +68,11 @@ extension JiraService {
             .catchError(.capture())
             .flatMap { (crpIssue: JiraService.CreatedIssue) -> Future<(JiraService.CreatedIssue, JiraService.FixedVersionReport)> in
                 // Create JIRA versions on each board then set Fixed Versions to that new version on each board's ticket included in Changelog
-                let report = try self.createAndSetFixedVersions(
+                return try self.createAndSetFixedVersions(
                     changelogSections: changelogSections,
                     versionName: jiraVersionName,
                     on: container
-                )
-                return report.map { (crpIssue, $0) }
+                ).map { (crpIssue, $0) }
         }
     }
 }

--- a/Sources/App/CRP/SlackCommand+CRP.swift
+++ b/Sources/App/CRP/SlackCommand+CRP.swift
@@ -46,7 +46,7 @@ extension SlackCommand {
                             commitMessages: commitMessages,
                             release: release,
                             repoMapping: repoMapping,
-                            crpProjectID: .init(id: "13402"), // CRP Board
+                            crpProjectID: JiraService.crpProjectID,
                             container: container
                         )
                     }

--- a/Sources/App/CRP/SlackCommand+CRP.swift
+++ b/Sources/App/CRP/SlackCommand+CRP.swift
@@ -42,8 +42,15 @@ extension SlackCommand {
                 return try github.changelog(for: release, on: container)
                     .catchError(.capture())
                     .flatMap { (commitMessages: [String]) -> Future<(JiraService.CreatedIssue, JiraService.FixedVersionReport)> in
-                        try jira.executeCRPTicketProcess(release: release, repoMapping: repoMapping, commitMessages: commitMessages, container: container)
+                        try jira.executeCRPTicketProcess(
+                            commitMessages: commitMessages,
+                            release: release,
+                            repoMapping: repoMapping,
+                            crpProjectID: .init(id: "13402"), // CRP Board
+                            container: container
+                        )
                     }
+                    .catchError(.capture())
                     .map { (crpIssue, report) in
                         let fixVersionReport = report.messages.isEmpty
                             ? "✅ Successfully added '\(repoMapping.crp.jiraVersionName(release))' in 'Fixed Versions' for all tickets"

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -30,6 +30,8 @@ private let jiraProjects = [
 
 /// Called before your application initializes.
 public func configure(_ config: inout Config, _ env: inout Environment, _ services: inout Services) throws {
+    let logger = PrintLogger()
+
     let slack = SlackService(
         token: try attempt { Environment.slackToken }
     )
@@ -42,7 +44,8 @@ public func configure(_ config: inout Config, _ env: inout Environment, _ servic
         baseURL: try attempt { Environment.jiraBaseURL.flatMap(URL.init(string:)) },
         username: try attempt { Environment.jiraUsername },
         password: try attempt { Environment.jiraToken },
-        knownProjects: jiraProjects
+        knownProjects: jiraProjects,
+        logger: logger
     )
 
     let github = GitHubService(

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -72,4 +72,8 @@ public func configure(_ config: inout Config, _ env: inout Environment, _ servic
     var middlewares = MiddlewareConfig()
     middlewares.use(ErrorMiddleware.self)
     services.register(middlewares)
+
+    // Some services (like JIRA) might need a slower client which handles rate-limiting APIs and quotas
+    let slowClient = SlowClient()
+    services.register(slowClient)
 }

--- a/Sources/Stevenson/JiraService+FieldTypes.swift
+++ b/Sources/Stevenson/JiraService+FieldTypes.swift
@@ -1,0 +1,86 @@
+import Vapor
+
+// MARK: Jira Common Field Types
+
+extension JiraService {
+    public enum FieldType {
+        public enum TextArea {
+            // See spec at: https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/
+
+            public struct Document: Content {
+                let type = "doc"
+                let content: [DocContent]
+                let version = 1
+                public init(content: [DocContent]) {
+                    self.content = content
+                }
+                public init(text: String) {
+                    self.content = [DocContent.paragraph([.text(text)])]
+                }
+            }
+
+            public struct DocContent: Content {
+                let type: String
+                let attrs: [String: AnyCodable]?
+                let content: [DocContent]?
+                let text: String?
+
+                fileprivate init(type: String, attrs: [String: Any]? = nil, content: [DocContent]? = nil, text: String? = nil) {
+                    self.type = type
+                    self.attrs = attrs.map { $0.mapValues { AnyCodable($0) } }
+                    self.content = content
+                    self.text = text
+                }
+
+                public static func heading(level: Int, title: String) -> DocContent {
+                    return DocContent(type: "heading", attrs: ["level": level], content: [.text(title)])
+                }
+
+                public static func bulletList(items: [ListItem]) -> DocContent {
+                    return DocContent(type: "bulletList", content: items.map { $0.content })
+                }
+
+                public static func paragraph(_ content: [DocContent]) -> DocContent {
+                    return DocContent(type: "paragraph", content: content)
+                }
+
+                public static func inlineCard(baseURL: URL, ticketKey: String) -> DocContent {
+                    let url = "\(baseURL)/browse/\(ticketKey)#icft=\(ticketKey)"
+                    return DocContent(type: "inlineCard", attrs: ["url": url], content: nil)
+                }
+
+                public static func text(_ text: String) -> DocContent {
+                    return DocContent(type: "text", text: text)
+                }
+
+                public static func hardbreak() -> DocContent {
+                    return DocContent(type: "hardBreak")
+                }
+            }
+
+            public struct ListItem {
+                let content: DocContent
+                public init(content: [DocContent]) {
+                    self.content = DocContent(
+                        type: "listItem",
+                        content: [DocContent.paragraph(content)]
+                    )
+                }
+            }
+        }
+
+        public struct ObjectID: Content {
+            let id: String
+            public init(id: String) {
+                self.id = id
+            }
+        }
+
+        public struct User: Content {
+            let name: String
+            public init(name: String) {
+                self.name = name
+            }
+        }
+    }
+}

--- a/Sources/Stevenson/JiraService.swift
+++ b/Sources/Stevenson/JiraService.swift
@@ -103,8 +103,8 @@ extension JiraService {
         let logMessage = "Creating a new issue <\(issue.fields.summary)> on board #\(issue.fields.project.id)"
         self.logger.info("[JIRA] \(logMessage)")
 
-        return try container.client()
-            .post(fullURL, headers: self.headers) { request in
+        return try container.make(SlowClient.self)
+            .post(fullURL, headers: self.headers, on: container) { request in
                 try request.content.encode(issue)
                 self.logRequest(logMessage, request)
             }
@@ -153,8 +153,8 @@ extension JiraService {
         let logMessage = "Creating a new JIRA version <\(version.name)> on board <\(projectKey)>"
         self.logger.info("[JIRA] \(logMessage)")
 
-        return try container.client()
-            .post(fullURL, headers: self.headers) { request in
+        return try container.make(SlowClient.self)
+            .post(fullURL, headers: self.headers, on: container) { request in
                 try request.content.encode(version)
                 self.logRequest(logMessage, request)
             }
@@ -198,8 +198,8 @@ extension JiraService {
         let logMessage = "Setting Fix Version field to <ID \(version.id ?? "nil")> (<\(version.name)>) for ticket <\(ticket)>"
         self.logger.info("[JIRA] \(logMessage)")
 
-        return try container.client()
-            .put(fullURL, headers: self.headers) { request in
+        return try container.make(SlowClient.self)
+            .put(fullURL, headers: self.headers, on: container) { request in
                 try request.content.encode(VersionAddUpdate(version: version))
                 self.logRequest(logMessage, request)
             }

--- a/Sources/Stevenson/JiraService.swift
+++ b/Sources/Stevenson/JiraService.swift
@@ -109,8 +109,10 @@ extension JiraService {
                 self.logRequest(logMessage, request)
             }
             .catchError(.capture())
-            .flatMap { response in
+            .do { response in
                 self.logResponse(logMessage, response)
+            }
+            .flatMap { response in
                 if response.http.status == .created {
                     return try response.content
                         .decode(CreatedIssue.self)
@@ -159,8 +161,10 @@ extension JiraService {
                 self.logRequest(logMessage, request)
             }
             .catchError(.capture())
-            .flatMap { response in
+            .do { response in
                 self.logResponse(logMessage, response)
+            }
+            .flatMap { response in
                 if response.http.status == .created {
                     return try response.content
                         .decode(Version.self)
@@ -204,8 +208,10 @@ extension JiraService {
                 self.logRequest(logMessage, request)
             }
             .catchError(.capture())
-            .flatMap { response -> Future<Response> in
+            .do { response in
                 self.logResponse(logMessage, response)
+            }
+            .flatMap { response -> Future<Response> in
                 guard response.http.status == .noContent else {
                     return try response.content
                         .decode(ServiceError.self)

--- a/Sources/Stevenson/JiraService.swift
+++ b/Sources/Stevenson/JiraService.swift
@@ -197,9 +197,9 @@ extension JiraService {
 extension JiraService {
     public struct Version: Content {
         public var id: String?
-        let projectId: Int
-        let description: String
-        let name: String
+        public let projectId: Int
+        public let description: String
+        public let name: String
         let released: Bool
         @CustomCodable<YMDDate>
         var startDate: Date
@@ -221,8 +221,16 @@ extension JiraService {
                 try $0.content.encode(version)
             }
             .catchError(.capture())
-            .flatMap {
-                try $0.content.decode(Version.self)
+            .flatMap { response in
+                print(response)
+                if response.http.status == .created {
+                    return try response.content
+                        .decode(Version.self)
+                } else {
+                    return try response.content
+                        .decode(ServiceError.self)
+                        .thenThrowing { throw $0 }
+                }
             }
             .catchError(.capture())
     }

--- a/Sources/Stevenson/JiraService.swift
+++ b/Sources/Stevenson/JiraService.swift
@@ -68,7 +68,7 @@ extension JiraService {
     }
 }
 
-// MARK: Issue creation
+// MARK: Issue creation API
 
 public protocol JiraIssueFields: Content {
     var project: JiraService.FieldType.ObjectID { get }
@@ -108,91 +108,7 @@ extension JiraService {
     }
 }
 
-
-// MARK: Jira Common Field Types
-
-extension JiraService {
-    public enum FieldType {
-        public enum TextArea {
-            // See spec at: https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/
-            
-            public struct Document: Content {
-                let type = "doc"
-                let content: [DocContent]
-                let version = 1
-                public init(content: [DocContent]) {
-                    self.content = content
-                }
-                public init(text: String) {
-                    self.content = [DocContent.paragraph([.text(text)])]
-                }
-            }
-
-            public struct DocContent: Content {
-                let type: String
-                let attrs: [String: AnyCodable]?
-                let content: [DocContent]?
-                let text: String?
-
-                fileprivate init(type: String, attrs: [String: Any]? = nil, content: [DocContent]? = nil, text: String? = nil) {
-                    self.type = type
-                    self.attrs = attrs.map { $0.mapValues { AnyCodable($0) } }
-                    self.content = content
-                    self.text = text
-                }
-
-                public static func heading(level: Int, title: String) -> DocContent {
-                    return DocContent(type: "heading", attrs: ["level": level], content: [.text(title)])
-                }
-
-                public static func bulletList(items: [ListItem]) -> DocContent {
-                    return DocContent(type: "bulletList", content: items.map { $0.content })
-                }
-
-                public static func paragraph(_ content: [DocContent]) -> DocContent {
-                    return DocContent(type: "paragraph", content: content)
-                }
-
-                public static func inlineCard(baseURL: URL, ticketKey: String) -> DocContent {
-                    let url = "\(baseURL)/browse/\(ticketKey)#icft=\(ticketKey)"
-                    return DocContent(type: "inlineCard", attrs: ["url": url], content: nil)
-                }
-
-                public static func text(_ text: String) -> DocContent {
-                    return DocContent(type: "text", text: text)
-                }
-
-                public static func hardbreak() -> DocContent {
-                    return DocContent(type: "hardBreak")
-                }
-            }
-
-            public struct ListItem {
-                let content: DocContent
-                public init(content: [DocContent]) {
-                    self.content = DocContent(
-                        type: "listItem",
-                        content: [DocContent.paragraph(content)]
-                    )
-                }
-            }
-        }
-
-        public struct ObjectID: Content {
-            let id: String
-            public init(id: String) {
-                self.id = id
-            }
-        }
-
-        public struct User: Content {
-            let name: String
-            public init(name: String) {
-                self.name = name
-            }
-        }
-    }
-}
+// MARK: JIRA Versions creation API
 
 extension JiraService {
     public struct Version: Content {
@@ -234,7 +150,10 @@ extension JiraService {
             }
             .catchError(.capture())
     }
+}
 
+// MARK: FixVersion field update API
+extension JiraService {
     public struct VersionAddUpdate: Content {
         let update: FixVersionUpdate
 

--- a/Sources/Stevenson/SlowClient.swift
+++ b/Sources/Stevenson/SlowClient.swift
@@ -1,0 +1,163 @@
+/// Service to create a Slow / Rate-Limiting-Aware Client, especially useful for 3rd-party APIs that have quotas or can't handle too many requests in parallel
+/// Borrowed from: https://gist.github.com/vzsg/3287030a9c9bdfc4aa726a5b0556e09e
+
+// SlowMode
+import Foundation
+import Dispatch
+import NIO
+// SlowClient
+import Vapor
+
+private final class SlowMode<T, U> {
+    private typealias Task = (T, EventLoopPromise<U>)
+    private let work: (T) -> EventLoopFuture<U>
+    private let verify: (U) -> (success: Bool, delay: Date?)
+    private let queue = DispatchQueue(label: "SlowMode [\(T.self) -> \(U.self)]")
+    private var deferredTasks: [Task] = []
+    private var currentTask: Task?
+    private var delayUntil: Date?
+
+    init(work: @escaping (T) -> EventLoopFuture<U>, verify: @escaping (U) -> (Bool, Date?) = { _ in (true, nil) }) {
+        self.work = work
+        self.verify = verify
+    }
+
+    func process(_ input: T, on eventLoop: EventLoop) -> EventLoopFuture<U> {
+        let promise = eventLoop.newPromise(U.self)
+        queue.async { self.dispatch((input, promise)) }
+        return promise.futureResult
+    }
+
+    private func dispatch(_ task: Task) {
+        let currentDate = Date()
+
+        if currentTask != nil {
+            // busy with another task -> enqueue
+            deferredTasks.insert(task, at: 0)
+            return
+        }
+
+        if let delayUntil = self.delayUntil, delayUntil > currentDate {
+            // previous task requested delay which has not expired yet -> wait until expiration
+            currentTask = task
+            queue.asyncAfter(deadline: .now() + delayUntil.timeIntervalSince(currentDate)) {
+                self.start(task)
+            }
+
+            return
+        }
+
+        // no running task, nor delay -> start request immediately
+        currentTask = task
+        start(task)
+    }
+
+    private func start(_ task: Task) {
+        let (input, promise) = task
+
+        let result = work(input)
+
+        result.whenSuccess { result in
+            let (success, delayUntil) = self.verify(result)
+
+            self.queue.async {
+                if success {
+                    self.delayUntil = delayUntil
+                    promise.succeed(result: result)
+                } else {
+                    // try again
+                    self.deferredTasks.append(task)
+                }
+
+                self.dispatchNext()
+            }
+        }
+
+        result.whenFailure { error in
+            promise.fail(error: error)
+
+            self.queue.async {
+                self.dispatchNext()
+            }
+        }
+    }
+
+    private func dispatchNext() {
+        currentTask = nil
+
+        if let nextTask = deferredTasks.popLast() {
+            dispatch(nextTask)
+        }
+    }
+}
+
+// MARK: SlowClient
+
+
+import Vapor
+
+public final class SlowClient: Service {
+    private let slowMode: SlowMode<Request, Response>
+
+    public init() {
+        slowMode = SlowMode(work: { req in
+            do {
+                let client = try req.client()
+                return client.send(req)
+            } catch {
+                return req.future(error: error)
+            }
+        }, verify: { response in
+            guard response.http.status.code == 429 else {
+                return (true, nil)
+            }
+
+            let delayUntil: Date
+
+            if let resetHeader = response.http.headers["X-RateLimit-Reset"].first,
+                let resetTime = TimeInterval(resetHeader) {
+                delayUntil = Date(timeIntervalSince1970: resetTime)
+            } else {
+                delayUntil = Date(timeIntervalSinceNow: 1)
+            }
+
+            return (false, delayUntil)
+        })
+    }
+
+    func send(_ request: Request) -> Future<Response> {
+        return slowMode.process(request, on: request.eventLoop)
+    }
+}
+
+extension SlowClient {
+    func get(_ url: URLRepresentable, headers: HTTPHeaders = [:], on container: Container, beforeSend: (Request) throws -> () = { _ in }) -> Future<Response> {
+        return send(.GET, headers: headers, to: url, on: container, beforeSend: beforeSend)
+    }
+
+    func post(_ url: URLRepresentable, headers: HTTPHeaders = [:], on container: Container, beforeSend: (Request) throws -> () = { _ in }) -> Future<Response> {
+        return send(.POST, headers: headers, to: url, on: container, beforeSend: beforeSend)
+    }
+
+    func patch(_ url: URLRepresentable, headers: HTTPHeaders = [:], on container: Container, beforeSend: (Request) throws -> () = { _ in }) -> Future<Response> {
+        return send(.PATCH, headers: headers, to: url, on: container, beforeSend: beforeSend)
+    }
+
+    func put(_ url: URLRepresentable, headers: HTTPHeaders = [:], on container: Container, beforeSend: (Request) throws -> () = { _ in }) -> Future<Response> {
+        return send(.PUT, headers: headers, to: url, on: container, beforeSend: beforeSend)
+    }
+
+    func delete(_ url: URLRepresentable, headers: HTTPHeaders = [:], on container: Container, beforeSend: (Request) throws -> () = { _ in }) -> Future<Response> {
+        return send(.DELETE, headers: headers, to: url, on: container, beforeSend: beforeSend)
+    }
+
+    func send(_ method: HTTPMethod, headers: HTTPHeaders = [:], to url: URLRepresentable, on container: Container, beforeSend: (Request) throws -> () = { _ in }) -> Future<Response> {
+        do {
+            let req = Request(http: .init(method: method, url: url, headers: headers), using: container)
+            try beforeSend(req)
+            return send(req)
+        } catch {
+            return container.eventLoop.newFailedFuture(error: error)
+        }
+    }
+}

--- a/Sources/Stevenson/SlowClient.swift
+++ b/Sources/Stevenson/SlowClient.swift
@@ -93,9 +93,6 @@ private final class SlowMode<T, U> {
 
 // MARK: SlowClient
 
-
-import Vapor
-
 public final class SlowClient: Service {
     private let slowMode: SlowMode<Request, Response>
 

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -70,6 +70,7 @@ final class AppTests: XCTestCase {
         )
         let issue = JiraService.makeCRPIssue(
             jiraBaseURL: jiraBaseURL,
+            crpProjectID: .init(id: "12345"),
             crpConfig: crpConfig,
             release: release,
             changelog: changelogDoc,
@@ -324,7 +325,7 @@ extension AppTests {
               "id" : "11439"
             },
             "project" : {
-              "id" : "13402"
+              "id" : "12345"
             },
             "customfield_12541" : "https:\/\/github.com\/company\/project\/releases\/tag\/app\/1.2.3",
             "customfield_11512" : {


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/IOSP-171

### Why?

The `/crp` command is consistently failing to assign create and assign JIRA Versions on some tickets when we trigger it from our Slack channel.

I tried multiple times to reproduce the issue with dummy tickets in CNSMR board and dummy CRP ticket creation (in the FCTP board which is supposed to be a test bed mirroring the CRP board), but failed to reproduce it (only reproduced it once, but didn't have the breakpoint in the right place at that time 😭)

### How?

With this lack of ability to reproduce in a debug session in Xcode, this PR instead:

* Adds more debug logs on every request/response send/received to JIRA API by the `JiraService`
* Also switched to use a `SlowClient` instead of the standard `request.client()` for those JIRA requests, in order to only send the requests one after the other serially, instead of in parallel (and to handle rate-limiting headers if present), in the hope that it might reduce the issue if it's indeed related to quotas as I originally suspect.

### PR checklist

* [x] I've assigned this PR to myself

With :heart:
