### PR TITLE
[IOSP-414] CRP Bot: Reuse existing Jira version if already existing

### DIFF
--- a/Sources/Stevenson/JiraService.swift
+++ b/Sources/Stevenson/JiraService.swift
@@ -137,8 +137,8 @@ extension JiraService {
         let released: Bool
         let startDate: CustomCodable<YMDDate>?
 
-        public init(projectId: Int, name: String, description: String?, released: Bool = false, startDate: Date?) {
-            self.id = nil
+        public init(id: String? = nil, projectId: Int, name: String, description: String?, released: Bool = false, startDate: Date?) {
+            self.id = id
             self.projectId = projectId
             self.name = name
             self.description = description

--- a/Sources/Stevenson/JiraService.swift
+++ b/Sources/Stevenson/JiraService.swift
@@ -102,27 +102,16 @@ extension JiraService {
 
         let logMessage = "Creating a new issue <\(issue.fields.summary)> on board #\(issue.fields.project.id)"
         self.logInfo(logMessage)
-
-        return try container.make(SlowClient.self)
-            .post(fullURL, headers: self.headers, on: container) { request in
-                try request.content.encode(issue)
-                self.logRequest(logMessage, request)
-            }
-            .catchError(.capture())
-            .do { response in
-                self.logResponse(logMessage, response)
-            }
-            .flatMap { response in
-                if response.http.status == .created {
-                    return try response.content
-                        .decode(CreatedIssue.self)
-                } else {
-                    return try response.content
-                        .decode(ServiceError.self)
-                        .thenThrowing { throw $0 }
+        return try request(.capture()) {
+            return try container.make(SlowClient.self)
+                .post(fullURL, headers: self.headers, on: container) { request in
+                    try request.content.encode(issue)
+                    self.logRequest(logMessage, request)
                 }
-            }
-            .catchError(.capture())
+                .do { response in
+                    self.logResponse(logMessage, response)
+                }
+        }
     }
 }
 
@@ -154,25 +143,15 @@ extension JiraService {
         let logMessage = "Fetching JIRA versions for board <\(projectKey)>"
         self.logInfo(logMessage)
 
-        return try container.make(SlowClient.self)
-            .get(fullURL, headers: self.headers, on: container) { request in
-                self.logRequest(logMessage, request)
-            }
-            .catchError(.capture())
-            .do { response in
-                self.logResponse(logMessage, response)
-            }
-            .flatMap { response in
-                if response.http.status == .ok {
-                    return try response.content
-                        .decode([Version].self)
-                } else {
-                    return try response.content
-                        .decode(ServiceError.self)
-                        .thenThrowing { throw $0 }
+        return try request(.capture()) {
+            return try container.make(SlowClient.self)
+                .get(fullURL, headers: self.headers, on: container) { request in
+                    self.logRequest(logMessage, request)
                 }
-            }
-            .catchError(.capture())
+                .do { response in
+                    self.logResponse(logMessage, response)
+                }
+        }
     }
 
     public func createVersion(_ version: Version, on container: Container) throws -> Future<Version> {
@@ -182,26 +161,16 @@ extension JiraService {
         let logMessage = "Creating a new JIRA version <\(version.name)> on board <\(projectKey)>"
         self.logInfo(logMessage)
 
-        return try container.make(SlowClient.self)
-            .post(fullURL, headers: self.headers, on: container) { request in
-                try request.content.encode(version)
-                self.logRequest(logMessage, request)
-            }
-            .catchError(.capture())
-            .do { response in
-                self.logResponse(logMessage, response)
-            }
-            .flatMap { response in
-                if response.http.status == .created {
-                    return try response.content
-                        .decode(Version.self)
-                } else {
-                    return try response.content
-                        .decode(ServiceError.self)
-                        .thenThrowing { throw $0 }
+        return try request(.capture()) {
+            return try container.make(SlowClient.self)
+                .post(fullURL, headers: self.headers, on: container) { request in
+                    try request.content.encode(version)
+                    self.logRequest(logMessage, request)
                 }
-            }
-            .catchError(.capture())
+                .do { response in
+                    self.logResponse(logMessage, response)
+                }
+        }
     }
 }
 
@@ -223,30 +192,22 @@ extension JiraService {
         }
     }
 
-    public func setFixedVersion(_ version: Version, for ticket: String, on container: Container) throws -> Future<Response> {
+    public func setFixedVersion(_ version: Version, for ticket: String, on container: Container) throws -> Future<Void> {
         let fullURL = URL(string: "/rest/api/3/issue/\(ticket)", relativeTo: baseURL)!
 
         let logMessage = "Setting Fix Version field to <ID \(version.id ?? "nil")> (<\(version.name)>) for ticket <\(ticket)>"
         self.logInfo(logMessage)
 
-        return try container.make(SlowClient.self)
-            .put(fullURL, headers: self.headers, on: container) { request in
-                try request.content.encode(VersionAddUpdate(version: version))
-                self.logRequest(logMessage, request)
-            }
-            .catchError(.capture())
-            .do { response in
-                self.logResponse(logMessage, response)
-            }
-            .flatMap { response -> Future<Response> in
-                guard response.http.status == .noContent else {
-                    return try response.content
-                        .decode(ServiceError.self)
-                        .thenThrowing { throw $0 }
+        return try request(.capture()) {
+            return try container.make(SlowClient.self)
+                .put(fullURL, headers: self.headers, on: container) { request in
+                    try request.content.encode(VersionAddUpdate(version: version))
+                    self.logRequest(logMessage, request)
                 }
-                return response.future(response)
-            }
-            .catchError(.capture())
+                .do { response in
+                    self.logResponse(logMessage, response)
+                }
+        }
     }
 }
 

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -14,15 +14,13 @@ final class AppTests: XCTestCase {
         "Merge remote-tracking branch 'origin/release/babylon/4.4.0' into develop",
     ]
 
-    static let fakeVersion: JiraService.Version = {
-        let v = JiraService.Version(
-            projectId: 123,
-            description: "Fake Version 1.2.3 for tests",
-            name: "Fake 1.2.3",
-            startDate: fixedGMTDate(year: 2019, month: 07, day: 10)
-        )
-        return v
-    }()
+    static let fakeVersion = JiraService.Version(
+        id: "42",
+        projectId: 123,
+        name: "Fake 1.2.3",
+        description: "Fake Version 1.2.3 for tests",
+        startDate: fixedGMTDate(year: 2019, month: 07, day: 10)
+    )
 
     func testReleaseType() {
         typealias ReleaseType = JiraService.CRPIssueFields.ReleaseType
@@ -87,6 +85,7 @@ final class AppTests: XCTestCase {
 
         let expected = #"""
             {
+              "id" : "42",
               "projectId" : 123,
               "startDate" : "2019-07-10",
               "description" : "Fake Version 1.2.3 for tests",
@@ -98,9 +97,7 @@ final class AppTests: XCTestCase {
     }
 
     func testAddVersion() throws {
-        var version = AppTests.fakeVersion
-        version.id = "42"
-        let update = JiraService.VersionAddUpdate(version: version)
+        let update = JiraService.VersionAddUpdate(version: AppTests.fakeVersion)
         addAttachment(name: "AddVersion", object: update)
 
         let expected = #"""


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/IOSP-414

### Why?

Some teams and PMs create the Version at the beginning of the sprint or during the sprint, essentially to forecast which tickets they plan to put in said version even before the release branch is cut.

This means that by the time the `/crp` command is run in Slack, some JIRA Versions already exist with the same version name that the bot wants to use

### How?

For each board, before creating a new version, first fetch the list of existing JIRA versions of the board and if there's one already existing with the proper `name`, reuse it. Only create a new version if there is none already existing with the expected name.

### PR checklist

* [x] I've assigned this PR to myself

With :heart:
