### PR TITLE
[IOSP-394] Add API route "/crp" to allow CRP process to be called from outside Slack

### DIFF
--- a/Sources/App/CRP/CRPProcess.swift
+++ b/Sources/App/CRP/CRPProcess.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Vapor
+import Stevenson
+
+enum CRPProcess {
+    enum Option: String {
+        case repo
+        case branch
+        case skipTicket
+        case skipFixVersion
+
+        func get<T: Decodable>(from request: Request) throws -> T {
+            guard let result = request.query[T.self, at: self.rawValue] else {
+                throw CRPProcess.Error.missingParameter(self.rawValue)
+            }
+            return result
+        }
+    }
+
+    enum Error: Swift.Error {
+        case invalidParameter(key: String, value: String, expected: String)
+        case missingParameter(String)
+    }
+
+    static func apiRequest(request: Request, github: GitHubService, jira: JiraService) throws -> Future<Response> {
+        let repo: String = try Option.repo.get(from: request)
+        let branch: String = try Option.branch.get(from: request)
+        let skipTicket: Bool = (try? Option.skipTicket.get(from: request)) ?? false
+        let skipFixVersion: Bool = (try? Option.skipFixVersion.get(from: request)) ?? false
+
+        guard let repoMapping = RepoMapping.all[repo.lowercased()] else {
+            throw CRPProcess.Error.invalidParameter(
+                key: Option.repo.rawValue,
+                value: repo,
+                expected: RepoMapping.all.keys.joined(separator: "|")
+            )
+        }
+
+        let release = try GitHubService.Release(
+            repo: repoMapping.repository,
+            branch: branch
+        )
+
+        return try github.changelog(for: release, on: request)
+            .catchError(.capture())
+            .flatMap { (commitMessages: [String]) -> Future<(JiraService.CreatedIssue?, JiraService.FixedVersionReport?)> in
+
+                let jiraVersionName = repoMapping.crp.jiraVersionName(release)
+                let changelogSections = ChangelogSection.makeSections(from: commitMessages, for: release)
+
+                // Create CRP ticket, unless skipped
+                let createTicket: Future<JiraService.CreatedIssue?>
+                if skipTicket {
+                    createTicket = request.future(nil)
+                } else {
+                    // Create CRP Issue
+                    let crpIssue = JiraService.makeCRPIssue(
+                        jiraBaseURL: jira.baseURL,
+                        crpProjectID: JiraService.crpProjectID,
+                        crpConfig: repoMapping.crp,
+                        release: release,
+                        changelog: jira.document(from: changelogSections)
+                    )
+
+                    createTicket = try jira.create(issue: crpIssue, on: request)
+                        .map { Optional.some($0) }
+                        .catchError(.capture())
+                }
+
+                return createTicket
+                    .flatMap { (crpIssue: JiraService.CreatedIssue?) -> Future<(JiraService.CreatedIssue?, JiraService.FixedVersionReport?)> in
+                        guard !skipFixVersion else {
+                            return request.future( (crpIssue, nil) )
+                        }
+                        // Create JIRA versions on each board then set Fixed Versions to that new version on each board's ticket included in Changelog
+                        return try jira.createAndSetFixedVersions(
+                            changelogSections: changelogSections,
+                            versionName: jiraVersionName,
+                            on: request
+                        ).map { (crpIssue, Optional.some($0)) }
+                }
+            }
+            .catchError(.capture())
+            .map { (crpIssue, report) in
+                var json: [String: AnyCodable] = [:]
+                if let ticket = crpIssue {
+                    json["ticket"] = AnyCodable([
+                        "key": ticket.key,
+                        "id": ticket.id,
+                        "url": "\(jira.baseURL)/browse/\(ticket.key)"
+                    ])
+                }
+                if let report = report {
+                    json["success"] = AnyCodable(report.messages.isEmpty)
+                    json["messages"] = AnyCodable(report.messages)
+                }
+                let response = Response(using: request)
+                try response.content.encode(json, as: .json)
+                return response
+            }
+    }
+}
+
+extension CRPProcess.Error: Debuggable {
+    var identifier: String {
+        switch self {
+        case .invalidParameter(key: let key, value: _, expected: _):
+            return "crp.invalidparameter.\(key)"
+        case .missingParameter(let key):
+            return "crp.missingparameter.\(key)"
+        }
+    }
+
+    var reason: String {
+        switch self {
+        case let .invalidParameter(key: key, value: value, expected: expected):
+            return #"Invalid value for parameter `\#(key)`: expected "\#(expected)", got "\#(value)"."#
+        case .missingParameter(let key):
+            return "Missing value for parameter `\(key)`."
+        }
+    }
+}

--- a/Sources/App/CRP/CRPProcess.swift
+++ b/Sources/App/CRP/CRPProcess.swift
@@ -63,7 +63,7 @@ enum CRPProcess {
                     )
 
                     createTicket = try jira.create(issue: crpIssue, on: request)
-                        .map { Optional.some($0) }
+                        .map(Optional.some)
                         .catchError(.capture())
                 }
 

--- a/Sources/App/CRP/ChangelogSection.swift
+++ b/Sources/App/CRP/ChangelogSection.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Stevenson
+
+struct ChangelogSection {
+    let board: String?
+    let commits: [(message: String, ticket: JiraService.TicketID?)]
+
+    /// Filters the CHANGELOG entries then orders and formats the CHANGELOG text
+    ///
+    /// - Parameters:
+    ///   - commits: The list of commits gathered between last release and current one
+    ///   - release: The release for which to build the CHANGELOG text for
+    /// - Returns: The text containing the filtered and formatted CHANGELOG, grouped and ordered by jira board
+    static func makeSections(from commits: [String], for release: GitHubService.Release) -> [ChangelogSection] {
+        // Only keep SDK commits if release is for SDK
+        let filteredMessages = release.isSDK ? commits.filter(hasSDKChanges) : commits
+        let parsedMessages = filteredMessages.map { (message: $0, ticket: JiraService.TicketID(from: $0)) }
+
+        // Group then sort the changes by JIRA boards (unclassified last)
+        return Dictionary(grouping: parsedMessages) { $0.ticket?.board }
+            .sorted { e1, e2 in e1.key ?? "ZZZ" < e2.key ?? "ZZZ" }
+            .map(ChangelogSection.init)
+    }
+
+    private static func hasSDKChanges(message: String) -> Bool {
+        return message.contains("#SDK") || message.range(of: #"\bSDK-[0-9]+\b"#, options: .regularExpression) != nil
+    }
+
+    func tickets() -> (String, [String])? {
+        guard let board = self.board else { return nil }
+        let ticketKeys = commits.compactMap { $0.ticket?.key }
+        return (board, ticketKeys)
+    }
+}

--- a/Sources/App/CRP/SlackCommand+CRP.swift
+++ b/Sources/App/CRP/SlackCommand+CRP.swift
@@ -71,35 +71,3 @@ extension SlackCommand {
         })
     }
 }
-
-struct ChangelogSection {
-    let board: String?
-    let commits: [(message: String, ticket: JiraService.TicketID?)]
-
-    /// Filters the CHANGELOG entries then orders and formats the CHANGELOG text
-    ///
-    /// - Parameters:
-    ///   - commits: The list of commits gathered between last release and current one
-    ///   - release: The release for which to build the CHANGELOG text for
-    /// - Returns: The text containing the filtered and formatted CHANGELOG, grouped and ordered by jira board
-    static func makeSections(from commits: [String], for release: GitHubService.Release) -> [ChangelogSection] {
-        // Only keep SDK commits if release is for SDK
-        let filteredMessages = release.isSDK ? commits.filter(hasSDKChanges) : commits
-        let parsedMessages = filteredMessages.map { (message: $0, ticket: JiraService.TicketID(from: $0)) }
-
-        // Group then sort the changes by JIRA boards (unclassified last)
-        return Dictionary(grouping: parsedMessages) { $0.ticket?.board }
-            .sorted { e1, e2 in e1.key ?? "ZZZ" < e2.key ?? "ZZZ" }
-            .map(ChangelogSection.init)
-    }
-
-    private static func hasSDKChanges(message: String) -> Bool {
-        return message.contains("#SDK") || message.range(of: #"\bSDK-[0-9]+\b"#, options: .regularExpression) != nil
-    }
-
-    func tickets() -> (String, [String])? {
-        guard let board = self.board else { return nil }
-        let ticketKeys = commits.compactMap { $0.ticket?.key }
-        return (board, ticketKeys)
-    }
-}

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -59,6 +59,7 @@ public func configure(_ config: inout Config, _ env: inout Environment, _ servic
         github: github,
         ci: ci,
         slack: slack,
+        jira: jira,
         commands: [
             .stevenson(ci, jira, github),
             .fastlane(ci),

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -7,6 +7,7 @@ public func routes(
     github: GitHubService,
     ci: CircleCIService,
     slack: SlackService,
+    jira: JiraService,
     commands: [SlackCommand]
 ) throws {
     router.get { req in
@@ -15,6 +16,10 @@ public func routes(
 
     router.post("github/comment") { (request) -> Future<Response> in
         try github.issueComment(on: request, ci: ci)
+    }
+
+    router.get("crp") { (request) -> Future<Response> in
+        try CRPProcess.apiRequest(request: request, github: github, jira: jira)
     }
 
     commands.forEach { command in


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/IOSP-394

### Why?

This is in preparation to allow the release cutoff automated process to call the CRP process from the `release_cutoff` script, in order to automate the triggering of CRP but also integrate the CRP ticket URL in the release PR

### How?

* Add a route to `/crp`, requiring `repo` and `branch` to be provided as query params
* Allow `skipTicket=1` and `skipFixVersion=1` as optional query parameters to be able to do the process in multiple stages
* Returned result and report as JSON

Everything is implemented in the `CRPProcess` namespace. the sequence of function calls is nearly the same as the functions called from `SlackCommand+CRP` (`github.changelog()` + `jira.create(issue:)` + `jira.createAndSetFixedVersions()`) but params parsing, optionality of checks and report as JSON is what makes it different.

### Future directions

Thanks to this new API, the `release_cutoff` script will later be able to (†):

* call this API with `skipFixVersion=1` first to get the CRP ticket created (but not trigger the FixVersion long dance)
* then create the release PR and include the CRP ticket URL in its description
* then call the API again with `skipTicket=1` to trigger the long dance of FixVersion updates – which can take a long time if JIRA decides to not timeout on many of the API calls

_(†) request pending in babylon repo_

### PR checklist

* [x] I've assigned this PR to myself

With :heart:
