### PR TITLE
[IOSP-535] Fix CRP automation process / reporting

### DIFF
--- a/Sources/App/CRP/CRPProcess.swift
+++ b/Sources/App/CRP/CRPProcess.swift
@@ -66,13 +66,13 @@ enum CRPProcess {
 
                 // Spawn a separate Future to trigger the "Fix Version dance" in the background
                 _ = ticketCreated.flatMap { (_, _) in
-                    try jira.createAndSetFixedVersions(
+                    try jira.createAndSetFixVersions(
                         changelogSections: changelogSections,
                         versionName: jiraVersionName,
                         on: request
                     )
                     .catchError(.capture())
-                    .flatMap { (report: JiraService.FixedVersionReport) -> Future<Response> in
+                    .flatMap { (report: JiraService.FixVersionReport) -> Future<Response> in
                         let message = report.fullReportText(releaseName: jiraVersionName)
                         return try slack.postMessage(message, channelID: channelID, on: request)
                             .catchError(.capture())
@@ -96,7 +96,7 @@ enum CRPProcess {
     }
 }
 
-extension JiraService.FixedVersionReport {
+extension JiraService.FixVersionReport {
     func fullReportText(releaseName: String) -> String {
         if messages.isEmpty {
             return "✅ Successfully added '\(releaseName)' in the 'Fix Version' field of all tickets"

--- a/Sources/App/CRP/CRPProcess.swift
+++ b/Sources/App/CRP/CRPProcess.swift
@@ -77,7 +77,7 @@ enum CRPProcess {
                 return crpResponse
             }
             .flatMap { crpIssue -> Future<JiraService.CreatedIssue> in
-                let message = "CRP Ticket created: <\(jira.browseURL(issue: crpIssue))|\(crpIssue.key)>"
+                let message = "✅ CRP Ticket created: <\(jira.browseURL(issue: crpIssue))|\(crpIssue.key)>"
                 return try slack.post(message: SlackMessage(channelID: channelID, text: message), on: request)
                     .map { _ in crpIssue }
                     .mapIfError { _ in crpIssue }

--- a/Sources/App/CRP/CRPProcess.swift
+++ b/Sources/App/CRP/CRPProcess.swift
@@ -96,21 +96,6 @@ enum CRPProcess {
     }
 }
 
-extension JiraService.FixVersionReport {
-    func fullReportText(releaseName: String) -> String {
-        if messages.isEmpty {
-            return "✅ Successfully added '\(releaseName)' in the 'Fix Version' field of all tickets"
-        } else {
-            return """
-                ❌ Some errors occurred when trying to add \(releaseName) in the 'Fix Version' field of some tickets.
-                Please double-check those tickets, you might need to fix them manually if needed.
-
-                \(self.description)"
-                """
-        }
-    }
-}
-
 extension CRPProcess.Error: Debuggable {
     var identifier: String {
         switch self {

--- a/Sources/App/CRP/CRPProcess.swift
+++ b/Sources/App/CRP/CRPProcess.swift
@@ -9,7 +9,7 @@ enum CRPProcess {
     enum Option: String {
         case repo
         case branch
-        case slack_channel_id
+        case slackChannelID = "slack_channel_id"
 
         func get<T: Decodable>(from request: Request) throws -> T {
             guard let result = request.query[T.self, at: self.rawValue] else {
@@ -27,7 +27,7 @@ enum CRPProcess {
     static func apiRequest(request: Request, github: GitHubService, jira: JiraService, slack: SlackService) throws -> Future<Response> {
         let repo: String = try Option.repo.get(from: request)
         let branch: String = try Option.branch.get(from: request)
-        let channelID: String = try Option.slack_channel_id.get(from: request)
+        let channelID: String = try Option.slackChannelID.get(from: request)
 
         guard let repoMapping = RepoMapping.all[repo.lowercased()] else {
             throw CRPProcess.Error.invalidParameter(

--- a/Sources/App/CRP/CRPProcess.swift
+++ b/Sources/App/CRP/CRPProcess.swift
@@ -2,6 +2,9 @@ import Foundation
 import Vapor
 import Stevenson
 
+/**
+ For detailed documentation of this part of the code, see: [Implementation Details documentation in private repo](https://github.com/babylonhealth/babylon-ios/blob/develop/Documentation/Process/Release%20process/CRP-Bot-ImplementationDetails.md#executing-the-crp-process)
+*/
 enum CRPProcess {
     enum Option: String {
         case repo

--- a/Sources/App/CRP/CRPProcess.swift
+++ b/Sources/App/CRP/CRPProcess.swift
@@ -71,7 +71,7 @@ enum CRPProcess {
                     .catchError(.capture())
                     .flatMap { (report: JiraService.FixVersionReport) -> Future<Response> in
                         let status = report.statusText(releaseName: jiraVersionName)
-                        let message = SlackMessage(channelID: channelID, text: status, attachments: report.asSlackAttachments())
+                        let message = SlackService.Message(channelID: channelID, text: status, attachments: report.asSlackAttachments())
                         return try slack.post(message: message, on: request)
                             .catchError(.capture())
                     }
@@ -81,7 +81,7 @@ enum CRPProcess {
             }
             .flatMap { crpIssue -> Future<JiraService.CreatedIssue> in
                 let message = "✅ CRP Ticket created: <\(jira.browseURL(issue: crpIssue))|\(crpIssue.key)>"
-                return try slack.post(message: SlackMessage(channelID: channelID, text: message), on: request)
+                return try slack.post(message: SlackService.Message(channelID: channelID, text: message), on: request)
                     .map { _ in crpIssue }
                     .mapIfError { _ in crpIssue }
             }
@@ -99,8 +99,8 @@ enum CRPProcess {
 }
 
 extension JiraService.FixVersionReport {
-    func asSlackAttachments() -> [SlackMessage.Attachment] {
-        return self.errors.map { error -> SlackMessage.Attachment in
+    func asSlackAttachments() -> [SlackService.Attachment] {
+        return self.errors.map { error -> SlackService.Attachment in
             switch error {
             case .notInWhitelist: return .warning(error.description)
             default: return .error(error.description)

--- a/Sources/App/CRP/CRPProcess.swift
+++ b/Sources/App/CRP/CRPProcess.swift
@@ -97,10 +97,10 @@ enum CRPProcess {
 
 extension JiraService.FixVersionReport {
     func asSlackAttachments() -> [SlackMessage.Attachment] {
-        return self.messages.map { message -> SlackMessage.Attachment in
-            switch message {
-            case .notInWhitelist: return .warning(message.description)
-            default: return .error(message.description)
+        return self.errors.map { error -> SlackMessage.Attachment in
+            switch error {
+            case .notInWhitelist: return .warning(error.description)
+            default: return .error(error.description)
             }
         }
     }

--- a/Sources/App/CRP/JiraService+CRP.swift
+++ b/Sources/App/CRP/JiraService+CRP.swift
@@ -274,9 +274,9 @@ extension JiraService {
     /// Used to report non-fatal errors without failing the Future chain
     struct FixVersionReport: CustomStringConvertible {
         enum Error: Swift.Error {
+            case notInWhitelist(project: String)
             case releaseCreationFailed(project: String, error: Swift.Error)
             case updateFixVersionFailed(ticket: String, url: String, error: Swift.Error)
-            case notInWhitelist(project: String)
         }
         let messages: [FixVersionReport.Error]
 
@@ -347,7 +347,7 @@ extension JiraService {
 // MARK: Nice report descriptions
 
 extension JiraService.FixVersionReport {
-    func fullReportText(releaseName: String) -> String {
+    func statusText(releaseName: String) -> String {
         if messages.isEmpty {
             return """
                 ✅ Successfully added "\(releaseName)" in the "Fix Version" field of all tickets
@@ -356,8 +356,6 @@ extension JiraService.FixVersionReport {
             return """
                 ❌ Some errors occurred when trying to add "\(releaseName)" in the "Fix Version" field of some tickets.
                 Please double-check those tickets, you might need to fix them manually if needed.
-
-                \(self.description)"
                 """
         }
     }
@@ -366,12 +364,12 @@ extension JiraService.FixVersionReport {
 extension JiraService.FixVersionReport.Error: CustomStringConvertible {
     var description: String {
         switch self {
+        case let .notInWhitelist(project):
+                return "Project `\(project)` is not part of our whitelist for creating JIRA versions"
         case let .releaseCreationFailed(project, error):
             return "Error creating JIRA release in board `\(project)` – \(error.betterLocalizedDescription)"
         case let .updateFixVersionFailed(ticket, url, error):
             return "Error setting Fix Version field for <\(url)|\(ticket)> – \(error.betterLocalizedDescription)"
-        case let .notInWhitelist(project):
-                return "Project `\(project)` is not part of our whitelist for creating JIRA versions"
         }
     }
 }

--- a/Sources/App/CRP/JiraService+CRP.swift
+++ b/Sources/App/CRP/JiraService+CRP.swift
@@ -289,7 +289,7 @@ extension JiraService {
 
         var description: String {
             return messages
-                .map { " - \($0.description)" }
+                .map { " • \($0.description)" }
                 .joined(separator: "\n")
         }
     }
@@ -344,15 +344,34 @@ extension JiraService {
     }
 }
 
+// MARK: Nice report descriptions
+
+extension JiraService.FixVersionReport {
+    func fullReportText(releaseName: String) -> String {
+        if messages.isEmpty {
+            return """
+                ✅ Successfully added "\(releaseName)" in the "Fix Version" field of all tickets
+                """
+        } else {
+            return """
+                ❌ Some errors occurred when trying to add "\(releaseName)" in the "Fix Version" field of some tickets.
+                Please double-check those tickets, you might need to fix them manually if needed.
+
+                \(self.description)"
+                """
+        }
+    }
+}
+
 extension JiraService.FixVersionReport.Error: CustomStringConvertible {
     var description: String {
         switch self {
         case let .releaseCreationFailed(project, error):
-            return "Error creating JIRA release in board \(project) [\(error.betterLocalizedDescription)]"
+            return "Error creating JIRA release in board `\(project)` – \(error.betterLocalizedDescription)"
         case let .updateFixVersionFailed(ticket, url, error):
-            return "Error setting Fix Version field for <\(url)|\(ticket)> [\(error.betterLocalizedDescription)]"
+            return "Error setting Fix Version field for <\(url)|\(ticket)> – \(error.betterLocalizedDescription)"
         case let .notInWhitelist(project):
-                return "Project \(project) is not part of our whitelist for creating JIRA versions"
+                return "Project `\(project)` is not part of our whitelist for creating JIRA versions"
         }
     }
 }
@@ -371,6 +390,6 @@ extension Error {
             default: return nil
             }
         }()
-        return message.map({ "\($0) (\(error.code))" }) ?? error.localizedDescription
+        return message.map({ "\($0) (\(error.code.rawValue))" }) ?? error.localizedDescription
     }
 }

--- a/Sources/App/CRP/JiraService+CRP.swift
+++ b/Sources/App/CRP/JiraService+CRP.swift
@@ -1,6 +1,10 @@
 import Vapor
 import Stevenson
 
+/**
+ For detailed documentation of this part of the code, see: [Implementation Details documentation in private repo](https://github.com/babylonhealth/babylon-ios/blob/develop/Documentation/Process/Release%20process/CRP-Bot-ImplementationDetails.md#executing-the-crp-process)
+*/
+
 // MARK: Constants
 
 // [CNSMR-1319] TODO: Use a config file to parametrise those
@@ -365,7 +369,7 @@ extension JiraService.FixVersionReport.Error: CustomStringConvertible {
     var description: String {
         switch self {
         case let .notInWhitelist(project):
-                return "Project `\(project)` is not part of our whitelist for creating JIRA versions"
+            return "Project `\(project)` is not part of our whitelist for creating JIRA versions"
         case let .releaseCreationFailed(project, error):
             return "Error creating JIRA release in board `\(project)` – \(error.betterLocalizedDescription)"
         case let .updateFixVersionFailed(ticket, url, error):

--- a/Sources/App/CRP/JiraService+CRP.swift
+++ b/Sources/App/CRP/JiraService+CRP.swift
@@ -355,7 +355,7 @@ extension JiraService.FixVersionReport {
         } else {
             return """
                 ❌ Some errors occurred when trying to add "\(releaseName)" in the "Fix Version" field of some tickets.
-                Please double-check those tickets, you might need to fix them manually if needed.
+                Please double-check those tickets; you might need to update some of them manually.
                 """
         }
     }

--- a/Sources/App/CRP/JiraService+CRP.swift
+++ b/Sources/App/CRP/JiraService+CRP.swift
@@ -278,17 +278,17 @@ extension JiraService {
             case releaseCreationFailed(project: String, error: Swift.Error)
             case updateFixVersionFailed(ticket: String, url: String, error: Swift.Error)
         }
-        let messages: [FixVersionReport.Error]
+        let errors: [FixVersionReport.Error]
 
-        init(_ message: FixVersionReport.Error) {
-            self.messages = [message]
+        init(_ error: FixVersionReport.Error) {
+            self.errors = [error]
         }
         init(reports: [FixVersionReport] = []) {
-            self.messages = reports.flatMap { $0.messages }
+            self.errors = reports.flatMap { $0.errors }
         }
 
         var description: String {
-            return messages
+            return errors
                 .map { " • \($0.description)" }
                 .joined(separator: "\n")
         }
@@ -348,7 +348,7 @@ extension JiraService {
 
 extension JiraService.FixVersionReport {
     func statusText(releaseName: String) -> String {
-        if messages.isEmpty {
+        if errors.isEmpty {
             return """
                 ✅ Successfully added "\(releaseName)" in the "Fix Version" field of all tickets
                 """

--- a/Sources/App/CRP/SlackCommand+CRP.swift
+++ b/Sources/App/CRP/SlackCommand+CRP.swift
@@ -52,10 +52,7 @@ extension SlackCommand {
                     }
                     .catchError(.capture())
                     .map { (crpIssue, report) in
-                        let fixVersionReport = report.messages.isEmpty
-                            ? "✅ Successfully added '\(repoMapping.crp.jiraVersionName(release))' in 'Fixed Versions' for all tickets"
-                            : "❌ Some errors occurred when trying to set 'Fixed Versions' on some tickets, you might need to fix them manually\n\(report)"
-
+                        let fixVersionReport = report.fullReportText(releaseName: repoMapping.crp.jiraVersionName(release))
                         return SlackResponse("""
                             ✅ CRP Ticket \(crpIssue.key) created.
                             \(jira.baseURL)/browse/\(crpIssue.key)

--- a/Sources/App/CRP/SlackCommand+CRP.swift
+++ b/Sources/App/CRP/SlackCommand+CRP.swift
@@ -56,8 +56,9 @@ extension SlackCommand {
                         return SlackService.Response("""
                             ✅ CRP Ticket \(crpIssue.key) created.
                             \(jira.baseURL)/browse/\(crpIssue.key)
-                            \(status)\n\(report)
+                            \(status)
                             """,
+                            attachments: report.asSlackAttachments(),
                             visibility: .channel
                         )
                     }.replyLater(

--- a/Sources/App/CRP/SlackCommand+CRP.swift
+++ b/Sources/App/CRP/SlackCommand+CRP.swift
@@ -41,7 +41,7 @@ extension SlackCommand {
 
                 return try github.changelog(for: release, on: container)
                     .catchError(.capture())
-                    .flatMap { (commitMessages: [String]) -> Future<(JiraService.CreatedIssue, JiraService.FixedVersionReport)> in
+                    .flatMap { (commitMessages: [String]) -> Future<(JiraService.CreatedIssue, JiraService.FixVersionReport)> in
                         try jira.executeCRPTicketProcess(
                             commitMessages: commitMessages,
                             release: release,

--- a/Sources/App/CRP/SlackCommand+CRP.swift
+++ b/Sources/App/CRP/SlackCommand+CRP.swift
@@ -52,11 +52,11 @@ extension SlackCommand {
                     }
                     .catchError(.capture())
                     .map { (crpIssue, report) in
-                        let fixVersionReport = report.fullReportText(releaseName: repoMapping.crp.jiraVersionName(release))
+                        let status = report.statusText(releaseName: repoMapping.crp.jiraVersionName(release))
                         return SlackResponse("""
                             ✅ CRP Ticket \(crpIssue.key) created.
                             \(jira.baseURL)/browse/\(crpIssue.key)
-                            \(fixVersionReport)
+                            \(status)\n\(report)
                             """,
                             visibility: .channel
                         )

--- a/Sources/App/CRP/SlackCommand+CRP.swift
+++ b/Sources/App/CRP/SlackCommand+CRP.swift
@@ -53,7 +53,7 @@ extension SlackCommand {
                     .catchError(.capture())
                     .map { (crpIssue, report) in
                         let status = report.statusText(releaseName: repoMapping.crp.jiraVersionName(release))
-                        return SlackResponse("""
+                        return SlackService.Response("""
                             ✅ CRP Ticket \(crpIssue.key) created.
                             \(jira.baseURL)/browse/\(crpIssue.key)
                             \(status)\n\(report)
@@ -61,7 +61,7 @@ extension SlackCommand {
                             visibility: .channel
                         )
                     }.replyLater(
-                        withImmediateResponse: SlackResponse("🎫 Creating ticket...", visibility: .channel),
+                        withImmediateResponse: SlackService.Response("🎫 Creating ticket...", visibility: .channel),
                         responseURL: metadata.responseURL,
                         on: container
                 )

--- a/Sources/App/Fastlane/SlackCommand+Fastlane.swift
+++ b/Sources/App/Fastlane/SlackCommand+Fastlane.swift
@@ -93,7 +93,7 @@ extension SlackCommand {
         branch: String? = nil,
         ci: CircleCIService,
         on container: Container
-    ) throws -> Future<SlackResponse> {
+    ) throws -> Future<SlackService.Response> {
         let branch = branch
             ?? metadata.value(forOption: .branch)
             ?? RepoMapping.ios.repository.baseBranch
@@ -117,7 +117,7 @@ extension SlackCommand {
         branch: String? = nil,
         ci: CircleCIService,
         on container: Container
-    ) throws -> Future<SlackResponse> {
+    ) throws -> Future<SlackService.Response> {
         let branch = branch
             ?? metadata.value(forOption: .branch)
             ?? RepoMapping.ios.repository.baseBranch
@@ -139,10 +139,10 @@ extension SlackCommand {
         to pipeline: Future<CircleCIService.PipelineResponse>,
         metadata: SlackCommandMetadata,
         on container: Container
-    ) -> Future<SlackResponse> {
+    ) -> Future<SlackService.Response> {
         return pipeline
             .map {
-                SlackResponse("""
+                SlackService.Response("""
                     You asked me: `\(metadata.command) \(metadata.text)`.
                     🚀 Triggered `\(metadata.textComponents[0])` on the `\($0.branch)` branch.
                     \($0.buildURL)
@@ -151,7 +151,10 @@ extension SlackCommand {
                 )
             }
             .replyLater(
-                withImmediateResponse: SlackResponse("👍 (If you don't receive response with the link to the triggered CI job in a few seconds please check CI logs before repeating a command)", visibility: .channel),
+                withImmediateResponse: SlackService.Response(
+                    "👍 (If you don't receive response with the link to the triggered CI job in a few seconds please check CI logs before repeating a command)",
+                    visibility: .channel
+                ),
                 responseURL: metadata.responseURL,
                 on: container
         )

--- a/Sources/App/app.swift
+++ b/Sources/App/app.swift
@@ -11,11 +11,20 @@ public func app(_ env: Environment) throws -> Application {
 }
 
 extension Environment {
+    /// Verification Token (see SlackBot App settings)
     static let slackToken       = Environment.get("SLACK_TOKEN")
+    /// Bot User OAuth Access Token (see SlackBot App settings)
+    static let slackOAuthToken  = Environment.get("SLACK_OAUTH_TOKEN")
+    /// GitHub Bot Username
     static let githubUsername   = Environment.get("GITHUB_USERNAME")
+    /// GitHub Bot Access Token
     static let githubToken      = Environment.get("GITHUB_TOKEN")
+    /// CircleCI Access Token
     static let circleciToken    = Environment.get("CIRCLECI_TOKEN")
+    /// JIRA Base URL, e.g. "https://yourorg.atlassian.net"
     static let jiraBaseURL      = Environment.get("JIRA_BASEURL")
+    /// JIRA Bot Username
     static let jiraUsername     = Environment.get("JIRA_USERNAME")
+    /// JIRA Bot Access Token
     static let jiraToken        = Environment.get("JIRA_TOKEN")
 }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -33,7 +33,8 @@ public func configure(_ config: inout Config, _ env: inout Environment, _ servic
     let logger = PrintLogger()
 
     let slack = SlackService(
-        token: try attempt { Environment.slackToken }
+        verificationToken: try attempt { Environment.slackToken },
+        oauthToken: try attempt { Environment.slackOAuthToken }
     )
 
     let ci = CircleCIService(

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -19,7 +19,7 @@ public func routes(
     }
 
     router.get("crp") { (request) -> Future<Response> in
-        try CRPProcess.apiRequest(request: request, github: github, jira: jira)
+        try CRPProcess.apiRequest(request: request, github: github, jira: jira, slack: slack)
     }
 
     commands.forEach { command in

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -29,7 +29,7 @@ public func routes(
                     try slack.handle(command: command, on: req)
                 }
             } catch {
-                return try SlackResponse(error: error).encode(for: req)
+                return try SlackService.Response(error: error).encode(for: req)
             }
         }
     }

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -18,7 +18,7 @@ public func routes(
         try github.issueComment(on: request, ci: ci)
     }
 
-    router.get("crp") { (request) -> Future<Response> in
+    router.post("api/crp") { (request) -> Future<Response> in
         try CRPProcess.apiRequest(request: request, github: github, jira: jira, slack: slack)
     }
 

--- a/Sources/Stevenson/Errors.swift
+++ b/Sources/Stevenson/Errors.swift
@@ -215,7 +215,7 @@ extension Future {
     }
 }
 
-extension SlackResponse {
+extension SlackService.Response {
     public init(error: Error, visibility: Visibility = .user) {
         #if DEBUG
         self.init(String(describing: error), visibility: visibility)

--- a/Sources/Stevenson/JiraService.swift
+++ b/Sources/Stevenson/JiraService.swift
@@ -226,3 +226,12 @@ extension JiraService {
         self.logger.debug("[JIRA-API] response for \(message):\n======>\n\(response)\n<======")
     }
 }
+
+extension JiraService {
+    public func browseURL(issue: CreatedIssue) -> String {
+        return self.browseURL(issue: issue.key)
+    }
+    public func browseURL(issue: String) -> String {
+        return "\(self.baseURL)/browse/\(issue)"
+    }
+}

--- a/Sources/Stevenson/JiraService.swift
+++ b/Sources/Stevenson/JiraService.swift
@@ -192,7 +192,7 @@ extension JiraService {
         }
     }
 
-    public func setFixedVersion(_ version: Version, for ticket: String, on container: Container) throws -> Future<Void> {
+    public func setFixVersion(_ version: Version, for ticket: String, on container: Container) throws -> Future<Void> {
         let fullURL = URL(string: "/rest/api/3/issue/\(ticket)", relativeTo: baseURL)!
 
         let logMessage = "Setting Fix Version field to <ID \(version.id ?? "nil")> (<\(version.name)>) for ticket <\(ticket)>"

--- a/Sources/Stevenson/SlackService.swift
+++ b/Sources/Stevenson/SlackService.swift
@@ -151,7 +151,7 @@ public struct SlackMessage: Content {
             .init(text: text, color: "36a64f")
         }
         public static func warning(_ text: String) -> Attachment {
-            .init(text: text, color: "ffa636")
+            .init(text: text, color: "fff000")
         }
         public static func error(_ text: String) -> Attachment {
             .init(text: text, color: "ff0000")

--- a/Sources/Stevenson/SlackService.swift
+++ b/Sources/Stevenson/SlackService.swift
@@ -126,15 +126,36 @@ public struct SlackResponse: Content {
 public struct SlackMessage: Content {
     public let channelID: String
     public let text: String
+    public let attachments: [Attachment]?
 
     enum CodingKeys: String, CodingKey {
         case channelID = "channel"
         case text
+        case attachments
     }
 
-    public init(channelID: String, text: String) {
+    public init(channelID: String, text: String, attachments: [Attachment]? = nil) {
         self.channelID = channelID
         self.text = text
+        self.attachments = attachments
+    }
+
+    public struct Attachment: Content {
+        let text: String
+        let color: String
+        public init(text: String, color: String) {
+            self.text = text
+            self.color = color
+        }
+        public static func success(_ text: String) -> Attachment {
+            .init(text: text, color: "36a64f")
+        }
+        public static func warning(_ text: String) -> Attachment {
+            .init(text: text, color: "ffa636")
+        }
+        public static func error(_ text: String) -> Attachment {
+            .init(text: text, color: "ff0000")
+        }
     }
 }
 
@@ -185,15 +206,6 @@ public struct SlackService {
                 try $0.content.encode(message)
         }
         .catchError(.capture())
-    }
-
-    /// Convenience for post(message: SlackMessage, on: Container)
-    public func postMessage(_ text: String, channelID: String, on container: Container) throws -> Future<Response> {
-        let message = SlackMessage(
-            channelID: channelID,
-            text: text
-        )
-        return try self.post(message: message, on: container)
     }
 }
 

--- a/Sources/Stevenson/SlackService.swift
+++ b/Sources/Stevenson/SlackService.swift
@@ -179,6 +179,7 @@ extension Future where T == SlackService.Response {
 extension SlackService {
     public struct Response: Content {
         public let text: String
+        public let attachments: [Attachment]?
         public let visibility: Visibility
 
         public enum Visibility: String, Content {
@@ -190,11 +191,13 @@ extension SlackService {
 
         enum CodingKeys: String, CodingKey {
             case text
+            case attachments
             case visibility = "response_type"
         }
 
-        public init(_ text: String, visibility: Visibility = .user) {
+        public init(_ text: String, attachments: [Attachment]? = nil, visibility: Visibility = .user) {
             self.text = text
+            self.attachments = attachments
             self.visibility = visibility
         }
     }

--- a/Sources/Stevenson/SlackService.swift
+++ b/Sources/Stevenson/SlackService.swift
@@ -141,18 +141,22 @@ public struct SlackMessage: Content {
 // MARK: Service
 
 public struct SlackService {
-    let token: String
+    /// Verification Token (see SlackBot App settings)
+    let verificationToken: String
+    /// Bot User OAuth Access Token (see SlackBot App settings)
+    let oauthToken: String
 
-    public init(token: String) {
-        self.token = token
+    public init(verificationToken: String, oauthToken: String) {
+        self.verificationToken = verificationToken
+        self.oauthToken = oauthToken
     }
 
     public func handle(command: SlackCommand, on request: Request) throws -> Future<Response> {
         return try request.content
             .decode(SlackCommandMetadata.self)
             .catchError(.capture())
-            .flatMap { [token] metadata in
-                guard metadata.token == token else {
+            .flatMap { [verificationToken] metadata in
+                guard metadata.token == verificationToken else {
                     throw Error.invalidToken
                 }
                 
@@ -174,7 +178,7 @@ public struct SlackService {
     public func post(message: SlackMessage, on container: Container) throws -> Future<Response> {
         let fullURL = URL(string: "https://slack.com/api/chat.postMessage")!
         let headers: HTTPHeaders = [
-            "Authorization": "Bearer \(self.token)"
+            "Authorization": "Bearer \(self.oauthToken)"
         ]
         return try container.client()
             .post(fullURL, headers: headers) {

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -180,10 +180,10 @@ final class AppTests: XCTestCase {
         let reportsPerProject = reports.map(JiraService.FixVersionReport.init(reports:))
         let consolidated = JiraService.FixVersionReport(reports: reportsPerProject)
         XCTAssertEqual(consolidated.description, """
-             - Project PRJ is not part of our whitelist for creating JIRA versions
-             - Error creating JIRA release in board PRJ [The operation couldn’t be completed. (NSURLErrorDomain error -1011.)]
-             - Error setting Fix Version field for <http://example.jira.org/browse/PRJ-123|PRJ-123> [Request timed out (Code(rawValue: -1001))]
-             - Error setting Fix Version field for <http://example.jira.org/browse/PRJ-456|PRJ-456> [Request timed out (Code(rawValue: -1001))]
+             • Project `PRJ` is not part of our whitelist for creating JIRA versions
+             • Error creating JIRA release in board `PRJ` – The operation couldn’t be completed. (NSURLErrorDomain error -1011.)
+             • Error setting Fix Version field for <http://example.jira.org/browse/PRJ-123|PRJ-123> – Request timed out (-1001)
+             • Error setting Fix Version field for <http://example.jira.org/browse/PRJ-456|PRJ-456> – Request timed out (-1001)
             """)
     }
 }

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -157,6 +157,35 @@ final class AppTests: XCTestCase {
         let error4 = try decoder.decode(JiraService.ServiceError.self, from: errorResponse4)
         XCTAssertEqual(error4.reason, "Unknown error")
     }
+
+    func testFixVersionReport() {
+        let reports: [[JiraService.FixVersionReport]] = [
+            [.init(),.init(),.init()],
+            [.init(.notInWhitelist(project: "PRJ"))],
+            [.init(.releaseCreationFailed(project: "PRJ", error: URLError(.badServerResponse)))],
+            [
+                .init(),
+                .init(),
+                .init(.updateFixVersionFailed(ticket: "PRJ-123", url: "http://example.jira.org/browse/PRJ-123", error: URLError(.timedOut))),
+                .init(),
+                .init()
+            ],
+            [
+                .init(),
+                .init(.updateFixVersionFailed(ticket: "PRJ-456", url: "http://example.jira.org/browse/PRJ-456", error: URLError(.timedOut))),
+                .init()
+            ],
+            [.init(),.init(),.init(),]
+        ]
+        let reportsPerProject = reports.map(JiraService.FixVersionReport.init(reports:))
+        let consolidated = JiraService.FixVersionReport(reports: reportsPerProject)
+        XCTAssertEqual(consolidated.description, """
+             - Project PRJ is not part of our whitelist for creating JIRA versions
+             - Error creating JIRA release in board PRJ [The operation couldn’t be completed. (NSURLErrorDomain error -1011.)]
+             - Error setting Fix Version field for <http://example.jira.org/browse/PRJ-123|PRJ-123> [Request timed out (Code(rawValue: -1001))]
+             - Error setting Fix Version field for <http://example.jira.org/browse/PRJ-456|PRJ-456> [Request timed out (Code(rawValue: -1001))]
+            """)
+    }
 }
 
 


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/IOSP-535

🤝 ⤴️ Companion PR in main repo: https://github.com/babylonhealth/babylon-ios/pull/10385

### Why?

Recently, the [CRP process](https://github.com/babylonhealth/babylon-ios/blob/develop/Documentation/Process/Release%20process/CRP-Bot.md) has been automated to be run for iOS on every release cut. 

But we had issues when trying to report the result of the long Fix Version dance, because [Heroku's routing layer times out no matter what after 30 seconds](https://devcenter.heroku.com/articles/request-timeout) – even if the server itself (Stevenson) was still working and the client (API triggered by fastlane) used a very long timeout.

### How?

* [The `release_cutoff.sh` script will now create the release channel first, and pass its ID to Stevenson](https://github.com/babylonhealth/babylon-ios/pull/10385)
* Once Stevenson has created the CRP ticket, it will take care of posting the link to Slack itself. Then returning the CRP ticket info to the caller (`release_cutoff.sh` / `fastlane`) right away
* In parallel, it will also start the Fix Version dance 💃. It will do that in the background, so that this won't block the HTTP response to the caller
* Finally, once the Fix Version dance is done, it will post another message to Slack with the full report.

This means that [the `release_cutoff.sh` script no longer has to post in Slack](https://github.com/babylonhealth/babylon-ios/pull/10385) itself, and will receive the response for its Stevenson API call quickly (= without risking to timeout at the router layer of heroku). That script will only use the response from the bot to include the CRP ticket URL in the release PR body.

### Other changes

* endpoint is now `POST` instead of `GET` (more REST-ful) and named `crp/api` (because `crp` was already taken by the slash command webhook)
* Error messages and reporting in Slack has been improved to be more readable and presented as Slack "attachments" (with nice color bars)

### Tested?

Edited my code locally to use the [FCTP testing board](https://babylonpartners.atlassian.net/browse/FCTP-53) and to return hard-coded `FixVersionReport` (instead of calling `jira.createAndSetFixVersions`). Then ran the instance locally, called `curl` passing the #ios-build channel ID to test it there, and [got some nice results](https://babylonhealth.slack.com/archives/C1Y6ZTH0T/p1579906198015100)

### PR checklist

* [x] I've assigned this PR to myself

With :heart:
