### PR TITLE
[IOSP-609] Fix JIRA API failing to post accountable person field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ xcuserdata
 *.xcodeproj
 DerivedData/
 .DS_Store
+
+# Used to store some local test scripts commonly used while experimenting
+#   or debug things, that we want to keep around but locally only, and
+#   should not commit remotely (as it might contain API tokens and similar)
+_local

--- a/Sources/App/CRP/JiraService+CRP.swift
+++ b/Sources/App/CRP/JiraService+CRP.swift
@@ -12,10 +12,16 @@ extension JiraService {
     /// Official CRP Board
     static let crpProjectID = FieldType.ObjectID(id: "13402")
 
-    static func accountablePerson(release: GitHubService.Release) -> String {
+    static func accountablePerson(release: GitHubService.Release) -> FieldType.User {
+        // To find the accountId to use here, open https://babylonpartners.atlassian.net/rest/api/3/user?username=<name> in your browser
+        let accountID: String
         let isTelus = release.appName.caseInsensitiveCompare("Telus") == .orderedSame
-        // Ensure to use a valid username key, check with https://babylonpartners.atlassian.net/rest/api/3/user?username=<name>
-        return isTelus ? "ryan.covill" : "mark.bates"
+        if isTelus {
+            accountID = "557058:8e407515-77cf-4466-a468-b3d386676a7f" // Ryan Covill
+        } else {
+            accountID = "5d77d4701e81950d2d821307" // Mark Bates
+        }
+        return FieldType.User(accountId: accountID)
     }
 
     /// Estimate time between when the CRP ticket is created and the app is released to the AppStore
@@ -44,7 +50,7 @@ extension JiraService {
             releaseType: .init(version: release.version),
             targetDate: targetDate ?? guessTargetDate(),
             changelog: changelog,
-            accountablePersonName: accountablePerson
+            accountablePerson: accountablePerson
         )
         return CRPIssue(fields: fields)
     }
@@ -172,7 +178,7 @@ extension JiraService {
             releaseType: ReleaseType,
             targetDate: Date,
             changelog: FieldType.TextArea.Document,
-            accountablePersonName: String
+            accountablePerson: FieldType.User
         ) {
             self.project = crpProjectID
             self.summary = summary
@@ -184,7 +190,7 @@ extension JiraService {
             self.jiraReleaseURL = "\(jiraBaseURL)/secure/Dashboard.jspa?selectPageId=15452"
             self.githubReleaseURL = "https://github.com/\(release.repository.fullName)/releases/tag/\(release.appName)/\(release.version)"
             self.testing = FieldType.TextArea.Document(text: "TBD")
-            self.accountablePerson = FieldType.User(name: accountablePersonName)
+            self.accountablePerson = accountablePerson
             self.infoSecChecked = .no
         }
     }

--- a/Sources/App/CRP/JiraService+CRP.swift
+++ b/Sources/App/CRP/JiraService+CRP.swift
@@ -385,7 +385,7 @@ extension JiraService.FixVersionReport.Error: CustomStringConvertible {
 }
 
 extension Error {
-    /// Just a nicer translation for some common URLErrors instead of the generic "The operation cound not be completed. (NSURLErrorDomain error N.)"
+    /// Just a nicer translation for some common URLErrors instead of the generic "The operation could not be completed. (NSURLErrorDomain error N.)"
     var betterLocalizedDescription: String {
         guard let error = self as? URLError else { return self.localizedDescription }
         let message: String? = {

--- a/Sources/App/CRP/JiraService+CRP.swift
+++ b/Sources/App/CRP/JiraService+CRP.swift
@@ -8,20 +8,19 @@ import Stevenson
 // MARK: Constants
 
 // [CNSMR-1319] TODO: Use a config file to parametrise those
+extension JiraService.FieldType.User  {
+      // To find the accountId to use here, open https://babylonpartners.atlassian.net/rest/api/3/user?username=<name> in your browser
+      static let RyanCovill = JiraService.FieldType.User(accountId: "557058:8e407515-77cf-4466-a468-b3d386676a7f")
+      static let MarkBates = JiraService.FieldType.User(accountId: "5d77d4701e81950d2d821307")
+}
+
 extension JiraService {
     /// Official CRP Board
     static let crpProjectID = FieldType.ObjectID(id: "13402")
 
     static func accountablePerson(release: GitHubService.Release) -> FieldType.User {
-        // To find the accountId to use here, open https://babylonpartners.atlassian.net/rest/api/3/user?username=<name> in your browser
-        let accountID: String
         let isTelus = release.appName.caseInsensitiveCompare("Telus") == .orderedSame
-        if isTelus {
-            accountID = "557058:8e407515-77cf-4466-a468-b3d386676a7f" // Ryan Covill
-        } else {
-            accountID = "5d77d4701e81950d2d821307" // Mark Bates
-        }
-        return FieldType.User(accountId: accountID)
+        return isTelus ? .RyanCovill : .MarkBates
     }
 
     /// Estimate time between when the CRP ticket is created and the app is released to the AppStore

--- a/Sources/Stevenson/JiraService+FieldTypes.swift
+++ b/Sources/Stevenson/JiraService+FieldTypes.swift
@@ -77,9 +77,9 @@ extension JiraService {
         }
 
         public struct User: Content {
-            let name: String
-            public init(name: String) {
-                self.name = name
+            let accountId: String
+            public init(accountId: String) {
+                self.accountId = accountId
             }
         }
     }

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -372,7 +372,7 @@ extension AppTests {
             "summary" : "Fake-Publish Dummy App v1.2.3",
             "customfield_12540" : "https:\/\/babylonpartners.atlassian.net:443\/secure\/Dashboard.jspa?selectPageId=15452",
             "customfield_11505" : {
-              "name" : "mark.bates"
+              "accountId" : "5d77d4701e81950d2d821307"
             },
             "customfield_12592" : [
               {

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -159,10 +159,11 @@ final class AppTests: XCTestCase {
     }
 
     func testFixVersionReport() {
+        let someError = URLError(.badServerResponse)
         let reports: [[JiraService.FixVersionReport]] = [
             [.init(),.init(),.init()],
             [.init(.notInWhitelist(project: "PRJ"))],
-            [.init(.releaseCreationFailed(project: "PRJ", error: URLError(.badServerResponse)))],
+            [.init(.releaseCreationFailed(project: "PRJ", error: someError))],
             [
                 .init(),
                 .init(),
@@ -181,7 +182,7 @@ final class AppTests: XCTestCase {
         let consolidated = JiraService.FixVersionReport(reports: reportsPerProject)
         XCTAssertEqual(consolidated.description, """
              • Project `PRJ` is not part of our whitelist for creating JIRA versions
-             • Error creating JIRA release in board `PRJ` – The operation couldn’t be completed. (NSURLErrorDomain error -1011.)
+             • Error creating JIRA release in board `PRJ` – \(someError.localizedDescription)
              • Error setting Fix Version field for <http://example.jira.org/browse/PRJ-123|PRJ-123> – Request timed out (-1001)
              • Error setting Fix Version field for <http://example.jira.org/browse/PRJ-456|PRJ-456> – Request timed out (-1001)
             """)

--- a/Tests/AppTests/XCTestManifests.swift
+++ b/Tests/AppTests/XCTestManifests.swift
@@ -7,8 +7,10 @@ extension AppTests {
     // to regenerate.
     static let __allTests__AppTests = [
         ("testAddVersion", testAddVersion),
+        ("testFixVersionReport", testFixVersionReport),
         ("testJiraDocumentFromCommits", testJiraDocumentFromCommits),
         ("testJiraErrors", testJiraErrors),
+        ("testReleaseType", testReleaseType),
         ("testVersion", testVersion),
     ]
 }


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/IOSP-609

### Why?

Recently the `/crp` command started to fail with JIRA API returning the following error:

![image](https://user-images.githubusercontent.com/216089/75819106-5031a900-5d9a-11ea-8f4c-8801d12bc6fe.png)


That field was and has always been passed into the JSON during the JIRA API call, and it worked before, so we have no idea why this started to suddenly fail. Sudden JIRA API change? Someone changing our JIRA instance's configuration? 🤷‍♂ 


### How?

After some investigation, it seems that using the user's `name`/`username` to identify a JIRA user does not always work for all users and JIRA instance configurations anymore. 

To fix this, we are now identifying the JIRA user by `accountId` rather than by their `name` (which we used previously)

### Tested?

Ran an instance of the bot locally and triggered the HTTP call (via `curl`) to simulate a `/crp android branch:release/babylon/4.18.0` command.
Confirmed that the CRP ticket failed before that change but passed once fix using `accountId` applied

### PR checklist

* [x] I've assigned this PR to myself

With :heart:
