### PR TITLE
[IOSP-623] Add SDKS as board filtered in for SDK

### DIFF
--- a/Sources/App/CRP/ChangelogSection.swift
+++ b/Sources/App/CRP/ChangelogSection.swift
@@ -23,7 +23,7 @@ struct ChangelogSection {
     }
 
     private static func hasSDKChanges(message: String) -> Bool {
-        return message.contains("#SDK") || message.range(of: #"\bSDK-[0-9]+\b"#, options: .regularExpression) != nil
+        return message.contains("#SDK") || message.range(of: #"\bSDKS?-[0-9]+\b"#, options: .regularExpression) != nil
     }
 
     func tickets() -> (String, [String])? {

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -9,6 +9,7 @@ final class AppTests: XCTestCase {
         // It's a trap! We don't want it to match "sdk-core" as a ticket reference from the SDK board
         "[CNSMR-1763] Migrate sdk-nhsgp into sdk-core (#8163)",
         "[SDK-4142] Commit 2",
+        "[IOSP-123] Update things here and there including in the #SDK",
         "[CNSMR-2045] Commit 3",
         // It's a trap! We don't want it to match "remote-tracking" as a ticket from the (non-existing) REMOTE board
         "Merge remote-tracking branch 'origin/release/babylon/4.4.0' into develop",
@@ -48,19 +49,22 @@ final class AppTests: XCTestCase {
         )
 
         let entries = ChangelogSection.makeSections(from: AppTests.fakeCommits, for: release)
-        XCTAssertEqual(entries.count, 4)
+        XCTAssertEqual(entries.count, 5)
         XCTAssertEqual(entries[0].board, "CNSMR")
         XCTAssertEqual(entries[0].commits.map { $0.message }, ["[CNSMR-2044] Commit 1", "[CNSMR-1763] Migrate sdk-nhsgp into sdk-core (#8163)", "[CNSMR-2045] Commit 3"])
         XCTAssertEqual(entries[0].commits.map { $0.ticket?.key }, ["CNSMR-2044", "CNSMR-1763", "CNSMR-2045"])
-        XCTAssertEqual(entries[1].board, "SDK")
-        XCTAssertEqual(entries[1].commits.map { $0.message }, ["[SDK-4142] Commit 2"])
-        XCTAssertEqual(entries[1].commits.map { $0.ticket?.key }, ["SDK-4142"])
-        XCTAssertEqual(entries[2].board, "SDKS")
-        XCTAssertEqual(entries[2].commits.map { $0.message }, ["[SDKS-1337] Commit 4"])
-        XCTAssertEqual(entries[2].commits.map { $0.ticket?.key }, ["SDKS-1337"])
-        XCTAssertEqual(entries[3].board, nil)
-        XCTAssertEqual(entries[3].commits.map { $0.message }, ["Merge remote-tracking branch 'origin/release/babylon/4.4.0' into develop"])
-        XCTAssertEqual(entries[3].commits.map { $0.ticket?.key }, [nil])
+        XCTAssertEqual(entries[1].board, "IOSP")
+        XCTAssertEqual(entries[1].commits.map { $0.message }, ["[IOSP-123] Update things here and there including in the #SDK"])
+        XCTAssertEqual(entries[1].commits.map { $0.ticket?.key }, ["IOSP-123"])
+        XCTAssertEqual(entries[2].board, "SDK")
+        XCTAssertEqual(entries[2].commits.map { $0.message }, ["[SDK-4142] Commit 2"])
+        XCTAssertEqual(entries[2].commits.map { $0.ticket?.key }, ["SDK-4142"])
+        XCTAssertEqual(entries[3].board, "SDKS")
+        XCTAssertEqual(entries[3].commits.map { $0.message }, ["[SDKS-1337] Commit 4"])
+        XCTAssertEqual(entries[3].commits.map { $0.ticket?.key }, ["SDKS-1337"])
+        XCTAssertEqual(entries[4].board, nil)
+        XCTAssertEqual(entries[4].commits.map { $0.message }, ["Merge remote-tracking branch 'origin/release/babylon/4.4.0' into develop"])
+        XCTAssertEqual(entries[4].commits.map { $0.ticket?.key }, [nil])
 
         let jiraBaseURL = URL(string: "https://babylonpartners.atlassian.net:443")!
         let changelogDoc = JiraService.document(from: entries, jiraBaseURL: jiraBaseURL)
@@ -91,13 +95,16 @@ final class AppTests: XCTestCase {
         )
 
         let entries = ChangelogSection.makeSections(from: AppTests.fakeCommits, for: release)
-        XCTAssertEqual(entries.count, 2)
-        XCTAssertEqual(entries[0].board, "SDK")
-        XCTAssertEqual(entries[0].commits.map { $0.message }, ["[SDK-4142] Commit 2"])
-        XCTAssertEqual(entries[0].commits.map { $0.ticket?.key }, ["SDK-4142"])
-        XCTAssertEqual(entries[1].board, "SDKS")
-        XCTAssertEqual(entries[1].commits.map { $0.message }, ["[SDKS-1337] Commit 4"])
-        XCTAssertEqual(entries[1].commits.map { $0.ticket?.key }, ["SDKS-1337"])
+        XCTAssertEqual(entries.count, 3)
+        XCTAssertEqual(entries[0].board, "IOSP")
+        XCTAssertEqual(entries[0].commits.map { $0.message }, ["[IOSP-123] Update things here and there including in the #SDK"])
+        XCTAssertEqual(entries[0].commits.map { $0.ticket?.key }, ["IOSP-123"])
+        XCTAssertEqual(entries[1].board, "SDK")
+        XCTAssertEqual(entries[1].commits.map { $0.message }, ["[SDK-4142] Commit 2"])
+        XCTAssertEqual(entries[1].commits.map { $0.ticket?.key }, ["SDK-4142"])
+        XCTAssertEqual(entries[2].board, "SDKS")
+        XCTAssertEqual(entries[2].commits.map { $0.message }, ["[SDKS-1337] Commit 4"])
+        XCTAssertEqual(entries[2].commits.map { $0.ticket?.key }, ["SDKS-1337"])
     }
 
     func testVersion() throws {
@@ -289,6 +296,43 @@ extension AppTests {
                             {
                               "type" : "text",
                               "text" : " Commit 3"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type" : "heading",
+                  "attrs" : {
+                    "level" : 3
+                  },
+                  "content" : [
+                    {
+                      "type" : "text",
+                      "text" : "IOSP tickets"
+                    }
+                  ]
+                },
+                {
+                  "type" : "bulletList",
+                  "content" : [
+                    {
+                      "type" : "listItem",
+                      "content" : [
+                        {
+                          "type" : "paragraph",
+                          "content" : [
+                            {
+                              "type" : "inlineCard",
+                              "attrs" : {
+                                "url" : "https:\/\/babylonpartners.atlassian.net:443\/browse\/IOSP-123#icft=IOSP-123"
+                              }
+                            },
+                            {
+                              "type" : "text",
+                              "text" : " Update things here and there including in the #SDK"
                             }
                           ]
                         }

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -6,12 +6,13 @@ import XCTest
 final class AppTests: XCTestCase {
     static let fakeCommits = [
         "[CNSMR-2044] Commit 1",
-        // trap: we don't want it to match "sdk-core" as a ticket reference from the SDK board
+        // It's a trap! We don't want it to match "sdk-core" as a ticket reference from the SDK board
         "[CNSMR-1763] Migrate sdk-nhsgp into sdk-core (#8163)",
         "[SDK-4142] Commit 2",
         "[CNSMR-2045] Commit 3",
-        // trap: we don't want it to match "remote-tracking" as a ticket from the (non-existing) REMOTE board
+        // It's a trap! We don't want it to match "remote-tracking" as a ticket from the (non-existing) REMOTE board
         "Merge remote-tracking branch 'origin/release/babylon/4.4.0' into develop",
+        "[SDKS-1337] Commit 4",
     ]
 
     static let fakeVersion = JiraService.Version(
@@ -47,16 +48,19 @@ final class AppTests: XCTestCase {
         )
 
         let entries = ChangelogSection.makeSections(from: AppTests.fakeCommits, for: release)
-        XCTAssertEqual(entries.count, 3)
+        XCTAssertEqual(entries.count, 4)
         XCTAssertEqual(entries[0].board, "CNSMR")
         XCTAssertEqual(entries[0].commits.map { $0.message }, ["[CNSMR-2044] Commit 1", "[CNSMR-1763] Migrate sdk-nhsgp into sdk-core (#8163)", "[CNSMR-2045] Commit 3"])
         XCTAssertEqual(entries[0].commits.map { $0.ticket?.key }, ["CNSMR-2044", "CNSMR-1763", "CNSMR-2045"])
         XCTAssertEqual(entries[1].board, "SDK")
         XCTAssertEqual(entries[1].commits.map { $0.message }, ["[SDK-4142] Commit 2"])
         XCTAssertEqual(entries[1].commits.map { $0.ticket?.key }, ["SDK-4142"])
-        XCTAssertEqual(entries[2].board, nil)
-        XCTAssertEqual(entries[2].commits.map { $0.message }, ["Merge remote-tracking branch 'origin/release/babylon/4.4.0' into develop"])
-        XCTAssertEqual(entries[2].commits.map { $0.ticket?.key }, [nil])
+        XCTAssertEqual(entries[2].board, "SDKS")
+        XCTAssertEqual(entries[2].commits.map { $0.message }, ["[SDKS-1337] Commit 4"])
+        XCTAssertEqual(entries[2].commits.map { $0.ticket?.key }, ["SDKS-1337"])
+        XCTAssertEqual(entries[3].board, nil)
+        XCTAssertEqual(entries[3].commits.map { $0.message }, ["Merge remote-tracking branch 'origin/release/babylon/4.4.0' into develop"])
+        XCTAssertEqual(entries[3].commits.map { $0.ticket?.key }, [nil])
 
         let jiraBaseURL = URL(string: "https://babylonpartners.atlassian.net:443")!
         let changelogDoc = JiraService.document(from: entries, jiraBaseURL: jiraBaseURL)
@@ -306,6 +310,43 @@ extension AppTests {
                             {
                               "type" : "text",
                               "text" : " Commit 2"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type" : "heading",
+                  "attrs" : {
+                    "level" : 3
+                  },
+                  "content" : [
+                    {
+                      "type" : "text",
+                      "text" : "SDKS tickets"
+                    }
+                  ]
+                },
+                {
+                  "type" : "bulletList",
+                  "content" : [
+                    {
+                      "type" : "listItem",
+                      "content" : [
+                        {
+                          "type" : "paragraph",
+                          "content" : [
+                            {
+                              "type" : "inlineCard",
+                              "attrs" : {
+                                "url" : "https:\/\/babylonpartners.atlassian.net:443\/browse\/SDKS-1337#icft=SDKS-1337"
+                              }
+                            },
+                            {
+                              "type" : "text",
+                              "text" : " Commit 4"
                             }
                           ]
                         }

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -84,6 +84,22 @@ final class AppTests: XCTestCase {
         XCTAssertEqualJSON(issue, AppTests.expectedTicketJson, "Ticket JSON Mismatch")
     }
 
+    func testFilteredCommitsForSDK() throws {
+        let release = try GitHubService.Release(
+            repo: GitHubService.Repository(fullName: "company/project", baseBranch: "develop"),
+            branch: "release/sdk/1.2.3"
+        )
+
+        let entries = ChangelogSection.makeSections(from: AppTests.fakeCommits, for: release)
+        XCTAssertEqual(entries.count, 2)
+        XCTAssertEqual(entries[0].board, "SDK")
+        XCTAssertEqual(entries[0].commits.map { $0.message }, ["[SDK-4142] Commit 2"])
+        XCTAssertEqual(entries[0].commits.map { $0.ticket?.key }, ["SDK-4142"])
+        XCTAssertEqual(entries[1].board, "SDKS")
+        XCTAssertEqual(entries[1].commits.map { $0.message }, ["[SDKS-1337] Commit 4"])
+        XCTAssertEqual(entries[1].commits.map { $0.ticket?.key }, ["SDKS-1337"])
+    }
+
     func testVersion() throws {
         addAttachment(name: "Version JSON", object: AppTests.fakeVersion)
 

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -13,6 +13,7 @@ final class AppTests: XCTestCase {
         "[CNSMR-2045] Commit 3",
         // It's a trap! We don't want it to match "remote-tracking" as a ticket from the (non-existing) REMOTE board
         "Merge remote-tracking branch 'origin/release/babylon/4.4.0' into develop",
+        "[IOSP-456] Nothing touching the SDK here",
         "[SDKS-1337] Commit 4",
     ]
 
@@ -54,8 +55,8 @@ final class AppTests: XCTestCase {
         XCTAssertEqual(entries[0].commits.map { $0.message }, ["[CNSMR-2044] Commit 1", "[CNSMR-1763] Migrate sdk-nhsgp into sdk-core (#8163)", "[CNSMR-2045] Commit 3"])
         XCTAssertEqual(entries[0].commits.map { $0.ticket?.key }, ["CNSMR-2044", "CNSMR-1763", "CNSMR-2045"])
         XCTAssertEqual(entries[1].board, "IOSP")
-        XCTAssertEqual(entries[1].commits.map { $0.message }, ["[IOSP-123] Update things here and there including in the #SDK"])
-        XCTAssertEqual(entries[1].commits.map { $0.ticket?.key }, ["IOSP-123"])
+        XCTAssertEqual(entries[1].commits.map { $0.message }, ["[IOSP-123] Update things here and there including in the #SDK", "[IOSP-456] Nothing touching the SDK here"])
+        XCTAssertEqual(entries[1].commits.map { $0.ticket?.key }, ["IOSP-123", "IOSP-456"])
         XCTAssertEqual(entries[2].board, "SDK")
         XCTAssertEqual(entries[2].commits.map { $0.message }, ["[SDK-4142] Commit 2"])
         XCTAssertEqual(entries[2].commits.map { $0.ticket?.key }, ["SDK-4142"])
@@ -98,7 +99,7 @@ final class AppTests: XCTestCase {
         XCTAssertEqual(entries.count, 3)
         XCTAssertEqual(entries[0].board, "IOSP")
         XCTAssertEqual(entries[0].commits.map { $0.message }, ["[IOSP-123] Update things here and there including in the #SDK"])
-        XCTAssertEqual(entries[0].commits.map { $0.ticket?.key }, ["IOSP-123"])
+        XCTAssertEqual(entries[0].commits.map { $0.ticket?.key }, ["IOSP-123"]) // but not IOSP-456 :)
         XCTAssertEqual(entries[1].board, "SDK")
         XCTAssertEqual(entries[1].commits.map { $0.message }, ["[SDK-4142] Commit 2"])
         XCTAssertEqual(entries[1].commits.map { $0.ticket?.key }, ["SDK-4142"])
@@ -333,6 +334,26 @@ extension AppTests {
                             {
                               "type" : "text",
                               "text" : " Update things here and there including in the #SDK"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type" : "listItem",
+                      "content" : [
+                        {
+                          "type" : "paragraph",
+                          "content" : [
+                            {
+                              "type" : "inlineCard",
+                              "attrs" : {
+                                "url" : "https:\/\/babylonpartners.atlassian.net:443\/browse\/IOSP-456#icft=IOSP-456"
+                              }
+                            },
+                            {
+                              "type" : "text",
+                              "text" : " Nothing touching the SDK here"
                             }
                           ]
                         }

--- a/Tests/AppTests/XCTestManifests.swift
+++ b/Tests/AppTests/XCTestManifests.swift
@@ -7,6 +7,7 @@ extension AppTests {
     // to regenerate.
     static let __allTests__AppTests = [
         ("testAddVersion", testAddVersion),
+        ("testFilteredCommitsForSDK", testFilteredCommitsForSDK),
         ("testFixVersionReport", testFixVersionReport),
         ("testJiraDocumentFromCommits", testJiraDocumentFromCommits),
         ("testJiraErrors", testJiraErrors),


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/IOSP-623

### Why?

SDK squad now have a new `SDKS` board that will soon replace the `SDK` board. We need to include tickets from this board to the SDK CRP ticket

### How?

* Update filter to include tickets matching `SDKS` too
* Added unit test

### Related PRs

* Update of Danger rule in main repo: https://github.com/babylonhealth/babylon-ios/pull/10933
* Update of Danger doc in playbook: https://github.com/babylonhealth/ios-playbook/pull/363

### PR checklist

* [x] I've assigned this PR to myself

With :heart:
