### PR TITLE
[IOSP-633] Add COVID bugs (next-gen) JIRA project to whitelist

### DIFF
--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -12,6 +12,7 @@ private let jiraProjects = [
     "CNSMR" : 16968, // Consumer Apps (Native/Core)
     "COCO"  : 17344, // Continuous Compliance
     "COREUS": 17127, // Babylon US Core Product
+    "COVIDBUGS": 17459, // COVID-19 hotfix bugs
     "CW"    : 16832, // Consumer Web
     "ETA"   : 17369, // Engagement Tribe - Activate
     "ETR"   : 17372, // Engagement Tribe - Retain


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/IOSP-633

### Why?
To include next-gen COVID bugs JIRA project that has the Releases functionality enabled.

### How?
Add project codes, IDs, and descriptors to /Sources/App/configure.swift

### PR checklist

* [x] I've assigned this PR to myself

With :heart:
