### PR TITLE
[CNSMR-3641] Add Mark for US releases, remove Wilson

### DIFF
--- a/Sources/App/CRP/JiraService+CRP.swift
+++ b/Sources/App/CRP/JiraService+CRP.swift
@@ -23,7 +23,7 @@ extension JiraService {
     static func accountablePerson(release: GitHubService.Release) -> FieldType.User {
         let isTelus = release.appName.caseInsensitiveCompare("Telus") == .orderedSame
         let isUS = release.appName.caseInsensitiveCompare("BabylonUS") == .orderedSame
-        return isTelus ? .RyanCovill : isUS ? .WilsonAmadi : .MarkBates
+        return isTelus ? .RyanCovill : isUS ? .MarkBates : .MarkBates
     }
 
     /// Estimate time between when the CRP ticket is created and the app is released to the AppStore

--- a/Sources/App/CRP/JiraService+CRP.swift
+++ b/Sources/App/CRP/JiraService+CRP.swift
@@ -13,7 +13,6 @@ extension JiraService.FieldType.User  {
       // or just type their name with `@` (mention) anywhere in JIRA ticket for editor to autocomplete it and replace with user id
       static let RyanCovill = JiraService.FieldType.User(accountId: "557058:8e407515-77cf-4466-a468-b3d386676a7f")
       static let MarkBates = JiraService.FieldType.User(accountId: "5d77d4701e81950d2d821307")
-      static let MarkBates = JiraService.FieldType.User(accountId: "5d77d4701e81950d2d821307")
 }
 
 extension JiraService {

--- a/Sources/App/CRP/JiraService+CRP.swift
+++ b/Sources/App/CRP/JiraService+CRP.swift
@@ -13,7 +13,7 @@ extension JiraService.FieldType.User  {
       // or just type their name with `@` (mention) anywhere in JIRA ticket for editor to autocomplete it and replace with user id
       static let RyanCovill = JiraService.FieldType.User(accountId: "557058:8e407515-77cf-4466-a468-b3d386676a7f")
       static let MarkBates = JiraService.FieldType.User(accountId: "5d77d4701e81950d2d821307")
-      static let WilsonAmadi = JiraService.FieldType.User(accountId: "5d0d1f7a4e8b120bc5cf9666")
+      static let MarkBates = JiraService.FieldType.User(accountId: "5d77d4701e81950d2d821307")
 }
 
 extension JiraService {


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/CNSMR-3641

### Why?
Wilson is no longer working at Babylon, so bot errors completing `Accountable Person`. Fix is to replace him with myself for now to allow CRPs to be generated for our US apps.

### How?
Removed Wilson's IDs and replaced them with mine.

### PR checklist

* [x] I've assigned this PR to myself

With :heart:
