### PR TITLE
[PDT-1419] Add support for array of environments for CRP tickets

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/vapor/core.git",
         "state": {
           "branch": null,
-          "revision": "18f2436bf7a6bc2224372c0885db2e0159af1649",
-          "version": "3.9.2"
+          "revision": "1782c550512dc5a43d0bca405e28fc386d932bbf",
+          "version": "3.10.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/vapor/crypto.git",
         "state": {
           "branch": null,
-          "revision": "df8eb7d8ae51787b3a0628aa3975e67666da936c",
-          "version": "3.3.3"
+          "revision": "105c2f875588bf40dd24c00cef3644bf8e327770",
+          "version": "3.4.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/vapor/http.git",
         "state": {
           "branch": null,
-          "revision": "3808ed0401379b6e9f4a053f03090ea9d658caa9",
-          "version": "3.2.1"
+          "revision": "0464b715a4b59f54078bcf7a4b424767b03db5a5",
+          "version": "3.4.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/vapor/multipart.git",
         "state": {
           "branch": null,
-          "revision": "b1992ef53fc9b38a0d9710be040cf19d9f63ad05",
-          "version": "3.1.0"
+          "revision": "fb216c5a8ef07dcd90aec8a4155e86c831acce97",
+          "version": "3.1.3"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "ba7970fe396e8198b84c6c1b44b38a1d4e2eb6bd",
-          "version": "1.14.1"
+          "revision": "8da5c5a4e6c5084c296b9f39dc54f00be146e0fa",
+          "version": "1.14.2"
         }
       },
       {
@@ -114,8 +114,8 @@
         "repositoryURL": "https://github.com/vapor/template-kit.git",
         "state": {
           "branch": null,
-          "revision": "51405c83e95e8adb09565278a5e9b959c605e56c",
-          "version": "1.4.0"
+          "revision": "4370aa99c01fc19cc8272b67bf7204b2d2063680",
+          "version": "1.5.0"
         }
       },
       {
@@ -123,8 +123,8 @@
         "repositoryURL": "https://github.com/vapor/url-encoded-form.git",
         "state": {
           "branch": null,
-          "revision": "82d8d63bdb76b6dd8febe916c639ab8608dbbaed",
-          "version": "1.0.6"
+          "revision": "20f68fbe7fac006d4d0617ea4edcba033227359e",
+          "version": "1.1.0"
         }
       },
       {
@@ -141,8 +141,8 @@
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "92a58a9a84e4330500b99fe355a94d29f67abe58",
-          "version": "3.3.1"
+          "revision": "642f3d4d1f0eafad651c85524d0d1c698b55399f",
+          "version": "3.3.3"
         }
       },
       {

--- a/Sources/App/CRP/JiraService+CRP.swift
+++ b/Sources/App/CRP/JiraService+CRP.swift
@@ -46,7 +46,7 @@ extension JiraService {
             jiraBaseURL: jiraBaseURL,
             crpProjectID: crpProjectID,
             summary: crpConfig.jiraSummary(release),
-            environments: [crpConfig.environment],
+            environments: crpConfig.environment,
             release: release,
             releaseType: .init(version: release.version),
             targetDate: targetDate ?? guessTargetDate(),

--- a/Sources/App/RepoMapping.swift
+++ b/Sources/App/RepoMapping.swift
@@ -6,7 +6,7 @@ struct RepoMapping {
     let crp: CRP
 
     struct CRP {
-        let environment: JiraService.CRPIssueFields.Environment
+        let environment: [JiraService.CRPIssueFields.Environment]
         let jiraVersionName: (GitHubService.Release) -> String
         let jiraSummary: (GitHubService.Release) -> String
     }
@@ -20,7 +20,7 @@ extension RepoMapping {
             baseBranch: "develop"
         ),
         crp: CRP(
-            environment: .appStore,
+            environment: [.appStore],
             jiraVersionName: {
                 let appName = $0.isSDK ? $0.appName.uppercased() : $0.appName
                 return "iOS \(appName) \($0.version)"
@@ -41,7 +41,7 @@ extension RepoMapping {
             baseBranch: "master"
         ),
         crp: CRP(
-            environment: .playStore,
+            environment: [.playStore],
             jiraVersionName: {
                 let appName = $0.isSDK ? $0.appName.uppercased() : $0.appName
                 return "Android \(appName) \($0.version)"

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -71,7 +71,7 @@ final class AppTests: XCTestCase {
         let changelogDoc = JiraService.document(from: entries, jiraBaseURL: jiraBaseURL)
 
         let crpConfig = RepoMapping.CRP(
-            environment: .appStore,
+            environment: [.appStore, .playStore],
             jiraVersionName: { _ in "Dummy Version 1.2.3" },
             jiraSummary: { _ in "Fake-Publish Dummy App v1.2.3" }
         )
@@ -521,6 +521,9 @@ extension AppTests {
             "customfield_12592" : [
               {
                 "id" : "12395"
+              },
+              {
+                "id" : "12394"
               }
             ],
             "customfield_12527" : {


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/PDT-1419

### Why?
<!--- Why this change is needed --->

We might need multiple environments for one CRP ticket (e.g. for cross-platform apps)

### How?
<!--- Details about the implementation --->

- Updated CRP env parameter to be an array
- Updated tests
- Updated to latest `vapor` minor version

### PR checklist
* [x] I've assigned this PR to myself

With :heart:
