### PR TITLE
[CNSMR-3695] Adjusted newline format & text for 'Change Scope' field

### DIFF
--- a/Sources/App/CRP/JiraService+CRP.swift
+++ b/Sources/App/CRP/JiraService+CRP.swift
@@ -207,15 +207,15 @@ extension JiraService {
             self.environments = environments
             self.releaseType = releaseType
             self.targetDate = targetDate
-            self.changeScope = FieldType.TextArea.Document(text: "There are a number of tickets from the Changelog that are yet to be moved to a completed status or resolution in their respective workflow. Each of these have been reviewed and commented on with why they do not impact the release, yet are in the codebase. These tickets are:")
+            self.changeScope = FieldType.TextArea.Document(text: "The headlines for the release are: \r\nThere are a number of tickets from the Changelog that are yet to be moved to a completed status or resolution in their respective workflow. Each of these have been reviewed and commented on with why they do not impact the release, yet are in the codebase. These tickets are:")
             self.jiraReleaseURL = "\(jiraBaseURL)/secure/Dashboard.jspa?selectPageId=15452"
             self.githubReleaseURL = "https://github.com/\(release.repository.fullName)/releases/tag/\(release.appName)/\(release.version)"
 
-            let testingContent = "Android & iOS native mobile apps PED Test Plan - https://docs.google.com/document/d/1GlvBD7DL0B24WOdky_sCJp3bewmwuHHkYfYcrPWDQEI/edit#heading=h.1jdzrbj14q2r \nTestRail milestone (automated & manual test runs) -\nCI branch pipeline (automated unit tests and build) - \nInternal release notes/QA sign-off -"
+            let testingContent = "Android & iOS native mobile apps PED Test Plan - https://docs.google.com/document/d/1GlvBD7DL0B24WOdky_sCJp3bewmwuHHkYfYcrPWDQEI/edit#heading=h.1jdzrbj14q2r \r\nTestRail milestone (automated & manual test runs) -\r\nCI branch pipeline (automated unit tests and build) - \r\nInternal release notes/QA sign-off -"
             self.testing = FieldType.TextArea.Document(text: testingContent)
             self.accountablePerson = accountablePerson
             self.infoSecChecked = .no
-            self.serviceChanges = FieldType.TextArea.Document(text: "Product Changes: \nService Changes: \nBOM:")
+            self.serviceChanges = FieldType.TextArea.Document(text: "Product Changes:")
             self.clinicalApproval = .unapproved
             self.regulatoryApproval = .unapproved
         }

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -490,7 +490,7 @@ extension AppTests {
                   "content" : [
                     {
                       "type" : "text",
-                      "text" : "Product Changes: \nService Changes: \nBOM:"
+                      "text" : "Product Changes:"
                     }
                   ]
                 }
@@ -506,7 +506,7 @@ extension AppTests {
                   "content" : [
                     {
                       "type" : "text",
-                      "text" : "Android & iOS native mobile apps PED Test Plan - https://docs.google.com/document/d/1GlvBD7DL0B24WOdky_sCJp3bewmwuHHkYfYcrPWDQEI/edit#heading=h.1jdzrbj14q2r \nTestRail milestone (automated & manual test runs) -\nCI branch pipeline (automated unit tests and build) - \nInternal release notes/QA sign-off -"
+                      "text" : "Android & iOS native mobile apps PED Test Plan - https://docs.google.com/document/d/1GlvBD7DL0B24WOdky_sCJp3bewmwuHHkYfYcrPWDQEI/edit#heading=h.1jdzrbj14q2r \r\nTestRail milestone (automated & manual test runs) -\r\nCI branch pipeline (automated unit tests and build) - \r\nInternal release notes/QA sign-off -"
                     }
                   ]
                 }
@@ -540,7 +540,7 @@ extension AppTests {
                   "content" : [
                     {
                       "type" : "text",
-                      "text" : "There are a number of tickets from the Changelog that are yet to be moved to a completed status or resolution in their respective workflow. Each of these have been reviewed and commented on with why they do not impact the release, yet are in the codebase. These tickets are:"
+                      "text" : "The headlines for the release are: \r\nThere are a number of tickets from the Changelog that are yet to be moved to a completed status or resolution in their respective workflow. Each of these have been reviewed and commented on with why they do not impact the release, yet are in the codebase. These tickets are:"
                     }
                   ]
                 }


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/CNSMR-3695

### Why?
1. The `\n` newline format does not seem to work with JIRA, so trying the Windows format of `\r\n`.
2. We need to give a high-level synopsis of the release content as well as the tickets that are not in a done-like status. I have adjusted the custom test to pre-format this (as well as remove redundant `BOM` and `Service change`).

### How?
Edited the custom field `self.changeScope = FieldType.TextArea.Document` to prompt this. Also updated tests.

### PR checklist

* [x] I've assigned this PR to myself

With :heart:
